### PR TITLE
Await the response to support async responses to await backend calls

### DIFF
--- a/src/fetch/types.ts
+++ b/src/fetch/types.ts
@@ -45,7 +45,7 @@ export namespace EdenFetch {
                 : { body?: unknown })
     ) => Promise<
         | {
-              data: Route['response']['200']
+              data: Awaited<Route['response']['200']>
               error: null
           }
         | {

--- a/src/treaty/types.ts
+++ b/src/treaty/types.ts
@@ -48,7 +48,7 @@ export namespace EdenTreaty {
                                             $fetch?: RequestInit
                                         }) => Promise<
                                             | {
-                                                  data: Route['response']['200']
+                                                  data: Awaited<Route['response']['200']>
                                                   error: null
                                               }
                                             | {
@@ -73,7 +73,7 @@ export namespace EdenTreaty {
                                             $fetch?: RequestInit
                                         }) => Promise<
                                             | {
-                                                  data: Route['response']['200']
+                                                  data: Awaited<Route['response']['200']>
                                                   error: null
                                               }
                                             | {
@@ -148,7 +148,7 @@ export namespace EdenTreaty {
                                         $fetch?: RequestInit
                                     }) => Promise<
                                         | {
-                                              data: Route['response']['200']
+                                              data: Awaited<Route['response']['200']>
                                               error: null
                                           }
                                         | {
@@ -173,7 +173,7 @@ export namespace EdenTreaty {
                                         $fetch?: RequestInit
                                     }) => Promise<
                                         | {
-                                              data: Route['response']['200']
+                                              data: Awaited<Route['response']['200']>
                                               error: null
                                           }
                                         | {


### PR DESCRIPTION
Allowing to 

```ts
// server.ts
const app = new Elysia()
  .post(
    '/create',
    async ({ body }) => {
      const awaitedData = await some()
      // { title: 'Hello World' }

      return awaitedData
    }
  )
  .listen(8080)
  
// client.ts
const appTreaty = edenTreaty<App>('http://localhost:8080');

const { data } = await appTreaty.create.post()
// data { title: 'Hello World' }
```

