### PR TITLE
fix: request method to always be uppercase

### DIFF
--- a/src/fetch/index.ts
+++ b/src/fetch/index.ts
@@ -33,6 +33,7 @@ export const edenFetch =
         // @ts-ignore
         const execute = () => fetch(server + endpoint + queryStr, {
             ...options,
+            method: options.method?.toUpperCase() || 'GET',
             headers: body
                 ? {
                       'content-type': 'application/json',

--- a/src/treaty/index.ts
+++ b/src/treaty/index.ts
@@ -178,7 +178,7 @@ const createProxy = (
             }[] = [{}]
         ) {
             const i = path.lastIndexOf('/'),
-                method = path.slice(i + 1),
+                method = path.slice(i + 1).toUpperCase(),
                 url = composePath(
                     domain,
                     i === -1 ? '/' : path.slice(0, i),
@@ -187,7 +187,7 @@ const createProxy = (
 
             const fetcher = config.fetcher ?? fetch
 
-            if (method === 'subscribe')
+            if (method === 'SUBSCRIBE')
                 return new EdenWS(
                     url.replace(
                         /^([^]+):\/\//,


### PR DESCRIPTION
Apparently, sending lowercase `patch` request method option to Cloudflare causes its' proxy to return `400` 