### PR TITLE
Add a way to get the unresolved Response for corner case support

### DIFF
--- a/src/treaty/index.ts
+++ b/src/treaty/index.ts
@@ -175,6 +175,7 @@ const createProxy = (
                     $fetch?: RequestInit
                     $headers?: HeadersInit
                     $query?: Record<string, string>
+                    getRaw?: boolean
                 },
                 {
                     fetch?: RequestInit
@@ -190,7 +191,7 @@ const createProxy = (
                     ? initialBody
                     : undefined
 
-            const { $query, $fetch, $headers, $transform, ...restBody } =
+            const { $query, $fetch, $headers, $transform, getRaw, ...restBody } =
                 initialBody ?? {}
 
             bodyObj ??= restBody
@@ -229,7 +230,7 @@ const createProxy = (
                     )
                 )
 
-            const execute = async () => {
+            const execute = async <T extends EdenTreaty.ExecuteOptions>(modifiers: T): Promise<EdenTreaty.ExecuteReturnType<T>> => {
                 let body: any
 
                 const headers = {
@@ -311,6 +312,7 @@ const createProxy = (
 
                 let data
 
+                if (modifiers.getRaw) return response as any
                 switch (response.headers.get('Content-Type')?.split(';')[0]) {
                     case 'application/json':
                         data = await response.json()
@@ -351,10 +353,10 @@ const createProxy = (
                     response: response,
                     status: response.status,
                     headers: response.headers
-                }
+                } as any
             }
 
-            return execute()
+            return execute({ getRaw })
         }
     }) as unknown as Record<string, unknown>
 

--- a/src/treaty/index.ts
+++ b/src/treaty/index.ts
@@ -125,7 +125,7 @@ export class EdenWS<Schema extends InputSchema<any> = InputSchema> {
                         }
                     else if (!Number.isNaN(+data)) data = +data
                     else if (data === 'true') data = true
-                    else if (data === 'fase') data = false
+                    else if (data === 'false') data = false
 
                     listener({
                         ...ws,

--- a/src/treaty/types.ts
+++ b/src/treaty/types.ts
@@ -119,6 +119,7 @@ export namespace EdenTreaty {
                         : ((
                                 params: {
                                     $fetch?: RequestInit
+                                    getRaw?: boolean
                                 } & (IsUnknown<Route['body']> extends false
                                     ? Replace<
                                           Route['body'],

--- a/src/treaty/types.ts
+++ b/src/treaty/types.ts
@@ -83,6 +83,14 @@ export namespace EdenTreaty {
         transform?: Transform
     }
 
+    export type DetailedResponse = {
+      data: any
+      error: any
+      response: Response
+      status: number
+      headers: Headers
+    };
+
     export type Sign<
         Schema extends Record<string, Record<string, unknown>>,
         Paths extends (string | number)[] = Split<keyof Schema & string>,
@@ -197,6 +205,11 @@ export namespace EdenTreaty {
         data: Data
         rawData: MessageEvent['data']
     }
+
+    export type ExecuteOptions = {
+      getRaw?: boolean
+    };
+    export type ExecuteReturnType<T extends ExecuteOptions> = T['getRaw'] extends true ? Response : DetailedResponse;
 
     export type WSEvent<
         K extends keyof WebSocketEventMap,


### PR DESCRIPTION
So this is not completely finished. I am not good enough with TypeScript to figure out how to modify the Sign type in the `src/treaty/type.ts` file to explicitly return a `Response` type when `getRaw: true` is used. I spent hours trying to figure it out.

This PR modifies edenTreaty:
```
EdenTreaty.<1>.<2>.<n>.<method>({
    ...body,
    $query?: {},
    $fetch?: RequestInit,
    getRaw?: boolean // Will cause the return type to be simply the unread Response object
})
```

See https://discord.com/channels/1044804142461362206/1182023123852345364

I welcome any suggestions on how to make the type capabilities of edenTreaty more accurate when working with this feature.