### PR TITLE
Fix invalid documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # @elysiajs/eden
-Fully type-safe Elysia client refers to the [documentation](https://elysiajs.com/plugins/eden/overview)
+Fully type-safe Elysia client refers to the [documentation](https://elysiajs.com/eden/overview)
 
 ## Installation
 ```bash


### PR DESCRIPTION
# Pull Request

Currently the link to the documentation in the README is not working. By adjusting the scope as `Eden` is not a regular plugin and not structured under it, this gets resolved.

## Notes

A related pull request for the actual `Elysia` documentation can be found here: https://github.com/elysiajs/documentation/pull/174