### PR TITLE
fix: params now optional for paramless routes in edenFetch

### DIFF
--- a/src/fetch/types.ts
+++ b/src/fetch/types.ts
@@ -32,7 +32,7 @@ export namespace EdenFetch {
                 : {
                       method: Method
                   }) &
-            (IsNever<keyof Route['params']> extends true
+            (IsNever<Route['params']> extends true
                 ? {
                       params?: Record<never, string>
                   }


### PR DESCRIPTION
Fixes #40 

Note:
We might want to add `"./test/**/*"` to tsconfig includes, as this could’ve been caught by tsc or linting the test files. I obviously didn’t do this as part of this PR as it is beyond scope and also highlights other issues (with `transform`)