### PR TITLE
🔧 fix(treaty): Fix regex for replacing http(s) with ws(s)

### DIFF
--- a/src/treaty/index.ts
+++ b/src/treaty/index.ts
@@ -231,7 +231,7 @@ const createProxy = (
             if (method === 'SUBSCRIBE')
                 return new EdenWS(
                     url.replace(
-                        /^([^]+):\/\//,
+                        /^([^:]+):\/\//,
                         url.startsWith('https://') ? 'wss://' : 'ws://'
                     )
                 )


### PR DESCRIPTION
I was reading through the source code and this regex looked like it was missing a `:`.