### PR TITLE
feat(treaty2): add keepDomain option

### DIFF
--- a/src/treaty2/index.ts
+++ b/src/treaty2/index.ts
@@ -363,13 +363,15 @@ export const treaty = <const App extends Elysia<any, any, any, any, any, any, an
     config: Treaty.Config = {}
 ): Treaty.Create<App> => {
     if (typeof domain === 'string') {
-        if (!domain.includes('://'))
-            domain =
-                (locals.find((v) => (domain as string).includes(v))
-                    ? 'http://'
-                    : 'https://') + domain
+        if (!config.keepDomain) {
+            if (!domain.includes('://'))
+                domain =
+                    (locals.find((v) => (domain as string).includes(v))
+                        ? 'http://'
+                        : 'https://') + domain
 
-        if (domain.endsWith('/')) domain = domain.slice(0, -1)
+            if (domain.endsWith('/')) domain = domain.slice(0, -1)
+        }
 
         return createProxy(domain, config)
     }

--- a/src/treaty2/types.ts
+++ b/src/treaty2/types.ts
@@ -129,6 +129,7 @@ export namespace Treaty {
             ) => MaybePromise<FetchRequestInit | void>
         >
         onResponse?: MaybeArray<(response: Response) => MaybePromise<unknown>>
+        keepDomain?: boolean
     }
 
     type UnwrapAwaited<T extends Record<number, unknown>> = {


### PR DESCRIPTION
closes #63 

Add a `keepDomain` option to treaty config that will prevent domain from being transformed when passed into treaty.