### PR TITLE
fix: 🐛 treaty2's request method to always be uppercase

### DIFF
--- a/src/treaty2/index.ts
+++ b/src/treaty2/index.ts
@@ -252,7 +252,7 @@ const createProxy = (
                             contentType = 'text/plain'
 
                     let fetchInit = {
-                        method,
+                        method: method?.toUpperCase(),
                         body,
                         ...conf,
                         headers: {


### PR DESCRIPTION
closes #61 