### PR TITLE
🐞 fix: use correct uppercase http verbs

### DIFF
--- a/src/treaty2/index.ts
+++ b/src/treaty2/index.ts
@@ -252,7 +252,7 @@ const createProxy = (
                             contentType = 'text/plain'
 
                     let fetchInit = {
-                        method,
+                        method: method?.toUpperCase(),
                         body,
                         ...conf,
                         headers: {


### PR DESCRIPTION
By standard the "PATCH" HTTP verb is not normalized: https://fetch.spec.whatwg.org/#example-normalization
This leads to very hard to debug errors in some scenarios. The small change capitalizes all HTTP verbs to prevent these kinds of errors.