### PR TITLE
fix(treaty2): use null as default error value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.6 - 21 Mar 2024
+Change:
+- treaty2: use null as default error value instead of undefined
+
 # 1.0.5 - 20 Mar 2024
 Change:
 - treaty2: use null as default data value instead of undefined

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elysiajs/eden",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Fully type-safe Elysia client",
   "author": {
     "name": "saltyAom",

--- a/src/treaty2/index.ts
+++ b/src/treaty2/index.ts
@@ -288,7 +288,7 @@ const createProxy = (
                     ) ?? fetcher!(url, fetchInit))
 
                     let data = null
-                    let error
+                    let error = null
 
                     if (onResponse) {
                         if (!Array.isArray(onResponse))

--- a/test/treaty2.test.ts
+++ b/test/treaty2.test.ts
@@ -99,15 +99,17 @@ const client = treaty(app)
 
 describe('Treaty2', () => {
     it('get index', async () => {
-        const { data } = await client.index.get()
+        const { data, error } = await client.index.get()
 
         expect(data).toBe('a')
+        expect(error).toBeNull()
     })
 
     it('post index', async () => {
-        const { data } = await client.index.get()
+        const { data, error } = await client.index.post()
 
         expect(data).toBe('a')
+        expect(error).toBeNull()
     })
 
     it('parse number', async () => {
@@ -378,7 +380,7 @@ describe('Treaty2', () => {
     })
 
     it('send date', async () => {
-        const { data, error } = await client.date.post({ date: new Date() })
+        const { data } = await client.date.post({ date: new Date() })
 
         expect(data).toBeInstanceOf(Date)
     })


### PR DESCRIPTION
Fixes [this issue](https://github.com/elysiajs/eden/commit/b10c17bbf18a30c7991adff80d05aeec30dae582).

If `data` is defined, `error` should be `null`, not `undefined`.

[This commit](https://github.com/elysiajs/eden/commit/b10c17bbf18a30c7991adff80d05aeec30dae582) fixed half the problem, setting `data` to `null` instead of `undefined` when the request errors. This does the same for `error`.