### PR TITLE
Eden Treaty V2 should not mutate the original paths array when making…

### DIFF
--- a/src/treaty2/index.ts
+++ b/src/treaty2/index.ts
@@ -89,8 +89,10 @@ const createProxy = (
                 (typeof body === 'object' && Object.keys(body).length !== 1) ||
                 method.includes(paths.at(-1) as any)
             ) {
-                const method = paths.pop()
-                const path = '/' + paths.join('/')
+
+                const methodPaths = [...paths];
+                const method = methodPaths.pop();
+                const path = '/' + methodPaths.join('/');
 
                 let {
                     fetcher = fetch,


### PR DESCRIPTION
… requests

See: https://discord.com/channels/1044804142461362206/1222687737098797116

Without this fix, you couldn't use the same treaty path object twice to execute requests. It would work the first time, but if tried to use it again, the request method would be lost.

This is because there was a mutation happening to the array used to contain the path information for the request, when really the mutation shouldn't be happening. A copy of the paths array is now created before extracting the method and construction the path string.