### PR TITLE
fix(treaty2): file getting sent as json

### DIFF
--- a/src/treaty2/index.ts
+++ b/src/treaty2/index.ts
@@ -195,11 +195,7 @@ const createProxy = (
                         options?.headers?.contentType
 
                     if (!contentType)
-                        if (typeof body === 'object') {
-                            contentType = 'application/json'
-
-                            body = JSON.stringify(body)
-                        } else if (hasFile(body)) {
+                        if (hasFile(body)) {
                             const formData = new FormData()
 
                             // FormData is 1 level deep
@@ -249,7 +245,12 @@ const createProxy = (
                                 formData.append(key, field as string)
                             }
 
+                            // contentType = 'multipart/form-data'
                             body = formData
+                        } else if (typeof body === 'object') {
+                            contentType = 'application/json'
+
+                            body = JSON.stringify(body)
                         } else if (body !== undefined && body !== null)
                             contentType = 'text/plain'
 
@@ -262,6 +263,9 @@ const createProxy = (
                             'content-type': contentType
                         }
                     } satisfies FetchRequestInit
+
+                    if (contentType === undefined)
+                        delete fetchInit.headers['content-type']
 
                     if (isGetOrHead) delete fetchInit.body
 


### PR DESCRIPTION
Trying to send an File will result in the Request getting sent as JSON, because the code handling files is unreachable since the object condition is also true.
Also the content-type header needs to be removed so the fetch API can set the form-data type with correct boundaries otherwise there is an issue on the Server.