### PR TITLE
fix: keep RequestInit for treaty2 and add tests

### DIFF
--- a/src/treaty2/index.ts
+++ b/src/treaty2/index.ts
@@ -308,7 +308,6 @@ const createProxy = (
                         }
 
                     const url = domain + path + q
-                    console.log('fetchInit', fetchInit)
                     const response = await (elysia?.handle(
                         new Request(url, fetchInit)
                     ) ?? fetcher!(url, fetchInit))

--- a/src/treaty2/index.ts
+++ b/src/treaty2/index.ts
@@ -201,6 +201,13 @@ const createProxy = (
                         )
                     }
 
+                    // Move RequestInit out of body
+                    if (body && typeof body === 'object' && 'fetch' in body)
+                        fetchInit = {
+                            ...fetchInit,
+                            ...fetchInit.body.fetch
+                        }
+
                     if (isGetOrHead) delete fetchInit.body
 
                     if (onRequest) {

--- a/src/treaty2/index.ts
+++ b/src/treaty2/index.ts
@@ -201,17 +201,15 @@ const createProxy = (
                         )
                     }
 
-                    // Move RequestInit out of body for GET and HEAD
-                    if (
-                        isGetOrHead &&
-                        body &&
-                        typeof body === 'object' &&
-                        'fetch' in body
-                    )
-                        fetchInit = {
-                            ...fetchInit,
-                            ...fetchInit.body.fetch
-                        }
+                    const fetchOpts =
+                        isGetOrHead && typeof body === 'object'
+                            ? body.fetch
+                            : options?.fetch
+
+                    fetchInit = {
+                        ...fetchInit,
+                        ...fetchOpts
+                    }
 
                     if (isGetOrHead) delete fetchInit.body
 
@@ -310,7 +308,7 @@ const createProxy = (
                         }
 
                     const url = domain + path + q
-
+                    console.log('fetchInit', fetchInit)
                     const response = await (elysia?.handle(
                         new Request(url, fetchInit)
                     ) ?? fetcher!(url, fetchInit))

--- a/src/treaty2/index.ts
+++ b/src/treaty2/index.ts
@@ -201,8 +201,13 @@ const createProxy = (
                         )
                     }
 
-                    // Move RequestInit out of body
-                    if (body && typeof body === 'object' && 'fetch' in body)
+                    // Move RequestInit out of body for GET and HEAD
+                    if (
+                        isGetOrHead &&
+                        body &&
+                        typeof body === 'object' &&
+                        'fetch' in body
+                    )
                         fetchInit = {
                             ...fetchInit,
                             ...fetchInit.body.fetch

--- a/test/treaty2.test.ts
+++ b/test/treaty2.test.ts
@@ -1,7 +1,7 @@
 import { Elysia, t } from 'elysia'
 import { treaty } from '../src'
 
-import { describe, expect, it } from 'bun:test'
+import { describe, expect, it, beforeAll, afterAll } from 'bun:test'
 
 const app = new Elysia()
     .get('/', 'a')
@@ -94,6 +94,10 @@ const app = new Elysia()
             date: t.Date()
         })
     })
+    .get(
+        '/redirect',
+        ({ set }) => (set.redirect = 'http://localhost:8083/true')
+    )
 
 const client = treaty(app)
 
@@ -383,5 +387,44 @@ describe('Treaty2', () => {
         const { data } = await client.date.post({ date: new Date() })
 
         expect(data).toBeInstanceOf(Date)
+    })
+    it('redirect should set location header', async () => {
+        const { headers, status } = await client['redirect'].get({
+            fetch: {
+                redirect: 'manual'
+            }
+        })
+        expect(status).toEqual(302)
+        expect(new Headers(headers).get('location')).toEqual(
+            'http://localhost:8083/true'
+        )
+    })
+})
+
+describe('Treaty2 - Using endpoint URL', () => {
+    const treatyApp = treaty<typeof app>('http://localhost:8083')
+
+    beforeAll(async () => {
+        await new Promise((resolve) => {
+            app.listen(8083, () => {
+                resolve(null)
+            })
+        })
+    })
+
+    afterAll(() => {
+        app.stop()
+    })
+
+    it('redirect should set location header', async () => {
+        const { headers, status } = await treatyApp.redirect.get({
+            fetch: {
+                redirect: 'manual'
+            }
+        })
+        expect(status).toEqual(302)
+        expect(new Headers(headers).get('location')).toEqual(
+            'http://localhost:8083/true'
+        )
     })
 })

--- a/test/treaty2.test.ts
+++ b/test/treaty2.test.ts
@@ -98,6 +98,15 @@ const app = new Elysia()
         '/redirect',
         ({ set }) => (set.redirect = 'http://localhost:8083/true')
     )
+    .post(
+        '/redirect',
+        ({ set }) => (set.redirect = 'http://localhost:8083/true'),
+        {
+            body: t.Object({
+                username: t.String()
+            })
+        }
+    )
 
 const client = treaty(app)
 
@@ -422,6 +431,23 @@ describe('Treaty2 - Using endpoint URL', () => {
                 redirect: 'manual'
             }
         })
+        expect(status).toEqual(302)
+        expect(new Headers(headers).get('location')).toEqual(
+            'http://localhost:8083/true'
+        )
+    })
+
+    it('redirect should set location header with post', async () => {
+        const { headers, status } = await treatyApp.redirect.post(
+            {
+                username: 'a'
+            },
+            {
+                fetch: {
+                    redirect: 'manual'
+                }
+            }
+        )
         expect(status).toEqual(302)
         expect(new Headers(headers).get('location')).toEqual(
             'http://localhost:8083/true'


### PR DESCRIPTION
Issue: https://github.com/elysiajs/elysia/issues/590

When using URL Endpoint with treaty2 the "fetch" object is being deleted for GET/HEAD requests and not passed to the fetcher.

https://github.com/elysiajs/eden/blob/dab2e53ac44539611b4545d3ee5ff937fa9f6b63/src/treaty2/index.ts#L204

This patch moves the RequestInit out of body and merges it with the "FetchRequestInit" object before "body" is deleted.

![image](https://github.com/elysiajs/eden/assets/17699163/fbdcc74f-64ef-4fa1-af57-d9a9ff8f894d)
