### PR TITLE
fix: 🐛 package.json export missing causing module federation to fail.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "exports": {
+    "./package.json": "./package.json",
     ".": {
       "require": "./dist/index.js",
       "import": "./dist/index.mjs",


### PR DESCRIPTION
While using Module Federation, the build and dev server fail because `package.json` is missing in the exports.
![image](https://github.com/elysiajs/eden/assets/48868969/ce214291-ff8a-4959-8165-fe8952cebd2a)

This should fix it.