### PR TITLE
Adjusts the creation of the query string.

### DIFF
--- a/src/treaty2/index.ts
+++ b/src/treaty2/index.ts
@@ -155,7 +155,7 @@ const createProxy = (
                 headers = processHeaders(headers, path, options)
 
                 const query = isGetOrHead
-                    ? (body as Record<string, string>)?.query
+                    ? (body as Record<string, string|string[]|undefined>)?.query
                     : options?.query
 
                 let q = ''

--- a/src/treaty2/index.ts
+++ b/src/treaty2/index.ts
@@ -159,9 +159,20 @@ const createProxy = (
                     : options?.query
 
                 let q = ''
-                if (query)
-                    for (const [key, value] of Object.entries(query))
-                        q += (q ? '&' : '?') + `${key}=${value}`
+                if (query) {
+                    const append = (key: string, value: string) => {
+                        q += (q ? '&' : '?') + `${encodeURIComponent(key)}=${encodeURIComponent(value)}`
+                    }
+
+                    for (const [key, value] of Object.entries(query)) {
+                        if (Array.isArray(value)) {
+                            for (const v of value) 
+                                append(key, v)
+                            continue
+                        }
+                        append(key, `${value}`)
+                    }
+                }
 
                 if (method === 'subscribe') {
                     const url =

--- a/test/treaty2.test.ts
+++ b/test/treaty2.test.ts
@@ -1,7 +1,7 @@
 import { Elysia, t } from 'elysia'
 import { treaty } from '../src'
 
-import { describe, expect, it } from 'bun:test'
+import { describe, expect, it, mock } from 'bun:test'
 
 const app = new Elysia()
     .get('/', 'a')
@@ -383,5 +383,59 @@ describe('Treaty2', () => {
         const { data } = await client.date.post({ date: new Date() })
 
         expect(data).toBeInstanceOf(Date)
+    })
+
+    it('doesn\'t encode if it doesn\'t need to', async () => {
+        const mockedFetch = mock(async () => new Response())
+        const client = treaty<typeof app>('', { fetcher: mockedFetch })
+
+        await client.index.get({
+            query: {
+                hello: 'world' 
+            }
+        })
+
+        expect(mockedFetch).toHaveBeenCalledWith(
+            expect.stringMatching(/\?hello=world$/g), {
+            headers: {},
+            method: 'GET'
+        })
+    })
+
+    it('encodes query parameters if it needs to', async () => {
+        const mockedFetch = mock(async () => new Response())
+        const client = treaty<typeof app>('', { fetcher: mockedFetch })
+
+        await client.index.get({
+            query: {
+                ['1/2']: '1/2'
+            }
+        })
+
+        expect(mockedFetch).toHaveBeenCalledWith(
+            // %1F is the encoded value for /
+            expect.stringMatching(/\?1%2F2=1%2F2$/g), {
+            headers: {},
+            method: 'GET'
+        })
+    })
+
+    it('accepts and serializes several values for the same query parameter', async () => {
+        const mockedFetch = mock(async () => new Response())
+        const client = treaty<typeof app>('', { fetcher: mockedFetch })
+
+        await client.index.get({
+            query: {
+                ['1/2']: ['1/2', '1 2']
+            }
+        })
+
+        expect(mockedFetch).toHaveBeenCalledWith(
+            // %2F is the encoded value for /
+            // %20 is the encoded value for space
+            expect.stringMatching(/\?1%2F2=1%2F2&1%2F2=1%202$/g), {
+            headers: {},
+            method: 'GET'
+        })
     })
 })


### PR DESCRIPTION
This pull requests  closes #83 and closes #82 .

* It adjusts the string concatenation to ensure query keys and values are URL encoded so they don't produce invalid URLs
* It also takes in account that the value of the `query: Record` can be an array of values, and properly serializes them
