### PR TITLE
Fixes serialization/deserialization problems with `null`, arrays and `Date` on websocket messages

### DIFF
--- a/src/treaty2/ws.ts
+++ b/src/treaty2/ws.ts
@@ -2,6 +2,8 @@ import type { InputSchema } from 'elysia'
 import type { Treaty } from './types'
 import { isNumericString } from '../treaty/utils'
 
+const ISO8601DateString = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/
+
 export class EdenWS<in out Schema extends InputSchema<any> = {}> {
     ws: WebSocket
 
@@ -61,10 +63,17 @@ export class EdenWS<in out Schema extends InputSchema<any> = {}> {
                 if (type === 'message') {
                     let data = (ws as MessageEvent).data.toString() as any
                     const start = data.charCodeAt(0)
-
+                    const end = data.charCodeAt(data.length - 1)
                     if (start === 47 || start === 123)
                         try {
-                            data = JSON.parse(data)
+                            data = JSON.parse(data, (key, value) => {
+                                if(typeof value === 'string' && ISO8601DateString.test(value)) {
+                                    const d = new Date(value)
+                                    if(!Number.isNaN(d.getTime())) 
+                                        return d
+                                }
+                                return value
+                            })
                         } catch {
                             // Not Empty
                         }
@@ -73,6 +82,9 @@ export class EdenWS<in out Schema extends InputSchema<any> = {}> {
                     else if (data === 'true') data = true
                     else if (data === 'false') data = false
                     else if (data === 'null') data = null
+                    // Remove " before parsing
+                    else if (start === 34 && end === 34 && ISO8601DateString.test(data))
+                        data = new Date(data.substring(1, data.length - 1))
 
                     listener({
                         ...ws,

--- a/src/treaty2/ws.ts
+++ b/src/treaty2/ws.ts
@@ -72,6 +72,7 @@ export class EdenWS<in out Schema extends InputSchema<any> = {}> {
                     else if (isNumericString(data)) data = +data
                     else if (data === 'true') data = true
                     else if (data === 'false') data = false
+                    else if (data === 'null') data = null
 
                     listener({
                         ...ws,

--- a/src/treaty2/ws.ts
+++ b/src/treaty2/ws.ts
@@ -64,7 +64,7 @@ export class EdenWS<in out Schema extends InputSchema<any> = {}> {
                     let data = (ws as MessageEvent).data.toString() as any
                     const start = data.charCodeAt(0)
                     const end = data.charCodeAt(data.length - 1)
-                    if (start === 47 || start === 123)
+                    if (start === 91 || start === 123)
                         try {
                             data = JSON.parse(data, (key, value) => {
                                 if(typeof value === 'string' && ISO8601DateString.test(value)) {


### PR DESCRIPTION
Ideally, messages would just be `Decoded` from Typebox's schema in order to determine whether to keep a date or parse it from a String.

- Adds tests
- Ensures we can parse Date strings
- Ensures we can parse arrays
- Ensures we can parse nested date-strings

closes #85 
(should) closes #54 
also closes #37 