### PR TITLE
Makes sure the headers are processed right before making a request

### DIFF
--- a/src/treaty2/index.ts
+++ b/src/treaty2/index.ts
@@ -229,31 +229,6 @@ const createProxy = (
 
                     if (isGetOrHead) delete fetchInit.body
 
-                    if (onRequest) {
-                        if (!Array.isArray(onRequest)) onRequest = [onRequest]
-
-                        for (const value of onRequest) {
-                            const temp = await value(path, fetchInit)
-
-                            if (typeof temp === 'object')
-                                fetchInit = {
-                                    ...fetchInit,
-                                    ...temp,
-                                    headers: {
-                                        ...fetchInit.headers,
-                                        ...processHeaders(
-                                            temp.headers,
-                                            path,
-                                            fetchInit
-                                        )
-                                    }
-                                }
-                        }
-                    }
-
-                    // ? Duplicate because end-user might add a body in onRequest
-                    if (isGetOrHead) delete fetchInit.body
-
                     if (hasFile(body)) {
                         const formData = new FormData()
 
@@ -333,11 +308,18 @@ const createProxy = (
                                     ...temp,
                                     headers: {
                                         ...fetchInit.headers,
-                                        ...temp.headers
-                                    } as Record<string, string>
+                                        ...processHeaders(
+                                            temp.headers,
+                                            path,
+                                            fetchInit
+                                        )
+                                    }
                                 }
                         }
                     }
+
+                    // ? Duplicate because end-user might add a body in onRequest
+                    if (isGetOrHead) delete fetchInit.body
 
                     const url = domain + path + q
                     const response = await (elysia?.handle(


### PR DESCRIPTION
The bug occurs because treaty "lower cases" all header values (not sure exactly why; I'd do nothing to them and let the platform handle the logic)

Since seems that some code got copy-pasted; and the latter appearance of the code copy-pasted code didn't process the headers it accumulated the headers as follows:

```typescript
// headers
{
  authorization: 'Bearer token',
  Authorization: 'Bearer token'
}
```

```typescript
const request = new Request({
    headers: {
        authorization: 'Bearer token',
        Authorization: 'Bearer token'
    }
})

console.log(request.header.get('Authorization')) // prints "Bearer token, Bearer token"
```

The fix is to remove the duplicated logic at the top and ensure "processHeaders" gets called.


closes #100 