### PR TITLE
Add parsing util to ws and treaty 1, also temporarily fix pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
             - name: Setup bun
               uses: oven-sh/setup-bun@v1
               with:
-                  bun-version: 1.0.12
+                  bun-version: 1.1.12
 
             - name: Install packages
               run: bun install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
             - name: Setup bun
               uses: oven-sh/setup-bun@v1
               with:
-                  bun-version: latest
+                  bun-version: 1.0.12
 
             - name: Install packages
               run: bun install

--- a/src/treaty2/index.ts
+++ b/src/treaty2/index.ts
@@ -423,7 +423,7 @@ const createProxy = (
                         default:
                             data = await response
                                 .text()
-                                .then(parseStringifiedValue) // Since this change, if the string contains a stringified JSOn, it will be parsed as such. Is it OK?
+                                .then(parseStringifiedValue)
                     }
 
                     if (response.status >= 300 || response.status < 200) {

--- a/src/treaty2/ws.ts
+++ b/src/treaty2/ws.ts
@@ -1,8 +1,6 @@
 import type { InputSchema } from 'elysia'
 import type { Treaty } from './types'
-import { isNumericString } from '../utils/parsingUtils'
-
-const ISO8601DateString = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z/
+import { parseStringifiedValue } from '../utils/parsingUtils'
 
 export class EdenWS<in out Schema extends InputSchema<any> = {}> {
     ws: WebSocket
@@ -61,35 +59,11 @@ export class EdenWS<in out Schema extends InputSchema<any> = {}> {
             type,
             (ws) => {
                 if (type === 'message') {
-                    let data = (ws as MessageEvent).data.toString() as any
-                    const start = data.charCodeAt(0)
-                    const end = data.charCodeAt(data.length - 1)
-                    if (start === 91 || start === 123)
-                        try {
-                            data = JSON.parse(data, (key, value) => {
-                                if (
-                                    typeof value === 'string' &&
-                                    ISO8601DateString.test(value)
-                                ) {
-                                    const d = new Date(value)
-                                    if (!Number.isNaN(d.getTime())) return d
-                                }
-                                return value
-                            })
-                        } catch {
-                            // Not Empty
-                        }
-                    else if (isNumericString(data)) data = +data
-                    else if (data === 'true') data = true
-                    else if (data === 'false') data = false
-                    else if (data === 'null') data = null
-                    // Remove " before parsing
-                    else if (
-                        start === 34 &&
-                        end === 34 &&
-                        ISO8601DateString.test(data)
-                    )
-                        data = new Date(data.substring(1, data.length - 1))
+                    const messageString = (ws as MessageEvent).data.toString()
+                    const data =
+                        messageString === 'null'
+                            ? null
+                            : parseStringifiedValue(messageString)
 
                     listener({
                         ...ws,

--- a/src/treaty2/ws.ts
+++ b/src/treaty2/ws.ts
@@ -1,6 +1,6 @@
 import type { InputSchema } from 'elysia'
 import type { Treaty } from './types'
-import { parseStringifiedValue } from '../utils/parsingUtils'
+import { parseMessageEvent } from '../utils/parsingUtils'
 
 export class EdenWS<in out Schema extends InputSchema<any> = {}> {
     ws: WebSocket
@@ -59,11 +59,7 @@ export class EdenWS<in out Schema extends InputSchema<any> = {}> {
             type,
             (ws) => {
                 if (type === 'message') {
-                    const messageString = (ws as MessageEvent).data.toString()
-                    const data =
-                        messageString === 'null'
-                            ? null
-                            : parseStringifiedValue(messageString)
+                    const data = parseMessageEvent(ws as MessageEvent)
 
                     listener({
                         ...ws,

--- a/src/utils/parsingUtils.ts
+++ b/src/utils/parsingUtils.ts
@@ -49,7 +49,7 @@ export const parseStringifiedObject = (data: string) =>
         return value
     })
 
-export const parseStringifiedValue = (value: any) => {
+export const parseStringifiedValue = (value: string) => {
     if (!value) {
         return value
     }

--- a/src/utils/parsingUtils.ts
+++ b/src/utils/parsingUtils.ts
@@ -80,3 +80,11 @@ export const parseStringifiedValue = (value: string) => {
 
     return value
 }
+
+export const parseMessageEvent = (event: MessageEvent) => {
+    const messageString = event.data.toString()
+
+    return messageString === 'null'
+        ? null
+        : parseStringifiedValue(messageString)
+}


### PR DESCRIPTION
I added the previously created in #105 parsingUtil usage to ws, and reshuffled some code in fetch to make it easier to understand and maintain.

P.S. while working on fetch I found some slightly weird things, for example, we always send the content header as `application/json` in case there is a body provided, even though other headers are seemingly supported (for example the body isn't `JSON.stringify`d in case the provided header isn't `application/json`)
@SaltyAom Can you provide some insight into why it's done like this?