### PR TITLE
feat: export Treaty namespace from treaty2

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,13 @@
       "default": "./dist/treaty.js",
       "types": "./dist/treaty/index.d.ts"
     },
+    "./treaty2": {
+      "require": "./dist/2.js",
+      "import": "./dist/treaty2.mjs",
+      "node": "./dist/treaty2.js",
+      "default": "./dist/treaty2.js",
+      "types": "./dist/treaty2/index.d.ts"
+    },
     "./fetch": {
       "require": "./dist/fetch.js",
       "import": "./dist/fetch.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,4 @@
-import type { Elysia } from 'elysia'
-
-import type { Treaty } from './treaty2'
-import type { EdenTreaty } from './treaty'
-import type { EdenFetch } from './fetch'
+export type { Treaty } from './treaty2'
 
 export { treaty } from './treaty2'
 export { edenTreaty } from './treaty'

--- a/src/treaty2/types.ts
+++ b/src/treaty2/types.ts
@@ -147,7 +147,7 @@ export namespace Treaty {
         [K in keyof T]: Awaited<T[K]>
     }
 
-    type TreatyResponse<
+    export type TreatyResponse<
         _Res extends Record<number, unknown>,
         Res extends Record<
             number,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -2,12 +2,11 @@ import { defineConfig } from 'tsup'
 import { resolve } from 'path'
 import { execSync } from 'child_process'
 
-import { copyFile } from 'fs/promises'
-
 export default defineConfig({
     entry: {
         index: resolve(__dirname, 'src/index.ts'),
         treaty: resolve(__dirname, 'src/treaty/index.ts'),
+        treaty2: resolve(__dirname, 'src/treaty2/index.ts'),
         fetch: resolve(__dirname, 'src/fetch/index.ts')
     },
     format: ['cjs', 'esm', 'iife'],


### PR DESCRIPTION
Hi,

While implementing a simple composable to facilitate using treaty2 with Nuxt, I noticed that treaty2's `Treaty` namespace and `TreatyResponse` type were not exported. 
We can currently import `EdenTreaty` and `EdenFetch` from `@elysiajs/eden/treaty` and `@elysiajs/eden/fetch` respectively, but not `Treaty`.

I also noticed that the types `Treaty`, `EdenTreaty` and `EdenFetch` were imported by the entrypoint, but were never used at all. Were they meant to be exported here ?

I'm not sure what solution would preferred, so I implemented two different solutions in two different commits:
- 1215bc3d124d9530623df8a0879b09b429455e42 which create a new named export: `@elysiajs/eden/treaty2`;
- 68ec5b1a4124734eed5fd56f1fdfb3f28691c455 that exports `Treaty` from `@elysiajs/eden`.
