### PR TITLE
Don't minify output files, makes it easier to debug Eden issues

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     },
     format: ['cjs', 'esm', 'iife'],
     globalName: 'Eden',
-    minify: true,
+    minify: false,
     external: ['elysia'],
     dts: true,
     async onSuccess() {


### PR DESCRIPTION
There is no need to minify files, it is responsability of the user bundler to do it.

Having an output closer to the original files source makes it easier to debug issues