### PR TITLE
fix(treaty2): ws response data type

### DIFF
--- a/src/treaty2/ws.ts
+++ b/src/treaty2/ws.ts
@@ -25,7 +25,7 @@ export class EdenWS<in out Schema extends InputSchema<any> = {}> {
 
     on<K extends keyof WebSocketEventMap>(
         type: K,
-        listener: (event: Treaty.WSEvent<K, Schema['response']>) => void,
+        listener: (event: Treaty.WSEvent<K, Schema['response'][200]>) => void,
         options?: boolean | AddEventListenerOptions
     ) {
         return this.addEventListener(type, listener, options)
@@ -43,7 +43,7 @@ export class EdenWS<in out Schema extends InputSchema<any> = {}> {
 
     subscribe(
         onMessage: (
-            event: Treaty.WSEvent<'message', Schema['response']>
+            event: Treaty.WSEvent<'message', Schema['response'][200]>
         ) => void,
         options?: boolean | AddEventListenerOptions
     ) {
@@ -52,7 +52,7 @@ export class EdenWS<in out Schema extends InputSchema<any> = {}> {
 
     addEventListener<K extends keyof WebSocketEventMap>(
         type: K,
-        listener: (event: Treaty.WSEvent<K, Schema['response']>) => void,
+        listener: (event: Treaty.WSEvent<K, Schema['response'][200]>) => void,
         options?: boolean | AddEventListenerOptions
     ) {
         this.ws.addEventListener(


### PR DESCRIPTION
# Summary

EdenWS has the wrong `event.data` type for all subscription-related listeners.

# Expected

When defining a `response` for the message, Eden should show that same type in the `event.data` for the callback argument in `EdenWS.on`, `EdenWS.subscribe`, and `EdenWS.addEventListener`.

# Solution
- Expects to receive the actual data type as the second generic [here](https://github.com/elysiajs/eden/blob/main/src/treaty2/types.ts#L223)
- Currently, it is being provided the entire response [here](https://github.com/elysiajs/eden/blob/main/src/treaty2/ws.ts#L28)
- To fix this, the `EdenWS` class should provided `Schema['response'][200]` as the data type for the second generic argument in `Treaty.WSEvent`

```ts
type Response = {
  // 200 is the HTTP code, and string is the actual response data.
  200: string
}

type EdenWSEvent_WRONG = Treaty.WSEvent<keyof WebSocketEventMap, Response>

type EdenWSEvent_CORRECT = Treaty.WSEvent<keyof WebSocketEventMap, Response[200]>
```

# Minimal Reproduction

```ts
import { Elysia, t } from 'elysia'
import { treaty } from '@elysiajs/eden'

const app = new Elysia().ws('/chat', {
    body: t.Object({ message: t.String() }),
    response: t.String(),
    message: async (_ws, body) => {
        body.message
    }
})

const api = treaty<typeof app>()

const subscription = api.chat.subscribe()

subscription.on('message', (event) => {
    event.data
    // ^? is { 200: { message: string } } instead of { message: string }
})
```
