### PR TITLE
fix: treat cases where query params can be null or Dates

### DIFF
--- a/src/treaty2/index.ts
+++ b/src/treaty2/index.ts
@@ -191,6 +191,11 @@ const createProxy = (
 					}
 
 					for (const [key, value] of Object.entries(query)) {
+						if (value === null || value instanceof Date) {
+							append(key, value)
+							continue
+						}
+						
 						if (Array.isArray(value)) {
 							for (const v of value) append(key, v)
 							continue


### PR DESCRIPTION
This PR improves on #115 once:
```js
typeof Date === "object"
typeof null === "object"
```
Other values may be in place but dates and nulls are the most used ones.