### PR TITLE
fix: formdata post, wrong inference of json payload

### DIFF
--- a/src/fetch/index.ts
+++ b/src/fetch/index.ts
@@ -63,24 +63,24 @@ export const edenFetch =
                 endpoint = endpoint.replace(`:${key}`, value as string)
             })
 
-        const contentType = options.headers?.['Content-Type']
-
-        if (!contentType || contentType === 'application/json')
-            try {
-                body = JSON.stringify(body)
-            } catch (error) {}
-
         const fetch = config?.fetcher || globalThis.fetch
         const queryStr = query
             ? `?${new URLSearchParams(query).toString()}`
             : ''
         const requestUrl = `${server}${endpoint}${queryStr}`
-        const headers = body
-            ? {
-                  'content-type': 'application/json',
-                  ...options.headers
-              }
-            : options.headers
+        const headers = new Headers(options.headers || {})
+        const contentType = headers.get('content-type')
+        if (
+            !(body instanceof FormData) &&
+            !(body instanceof URLSearchParams) &&
+            (!contentType || contentType === 'application/json')
+        ) {
+            try {
+                body = JSON.stringify(body)
+                if (!contentType) headers.set('content-type', 'application/json')
+            } catch (error) {}
+        }
+
         const init = {
             ...options,
             method: options.method?.toUpperCase() || 'GET',

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { Elysia, t } from 'elysia'
+import { Elysia, form, t } from 'elysia'
 import { edenFetch } from '../src'
 
 import { describe, expect, it, beforeAll } from 'bun:test'
@@ -13,6 +13,17 @@ const json = {
 const app = new Elysia()
     .get('/', () => 'hi')
     .post('/', () => 'post')
+    .post('/form-data', ({ body }) => {
+        return {
+            file: body.file.name,
+            size: body.file.size
+        }
+    }, {
+        body: t.Object({
+            file: t.File()
+        }),
+        parse: 'formdata'
+    })
     .get('/json', ({ body }) => json)
     .get(
         '/json-utf8',
@@ -137,6 +148,22 @@ describe('Eden Fetch', () => {
         const { data } = await fetch('/false', {})
 
         expect(data).toEqual(false)
+    })
+
+    it('parse form data', async () => {
+        const formData = new FormData();
+        formData.append('file', new File(['test'], 'test.txt', { type: 'text/plain' }))
+
+        const { data } = await fetch('/form-data', {
+            method: 'POST',
+            // @ts-ignore
+            body: formData
+        })
+
+        expect(data).toEqual({
+            file: 'test.txt',
+            size: 4
+        })
     })
 
     // ! FIX ME


### PR DESCRIPTION
Allow usage of FormData payloads and URLSearchParams. Using Headers, case-sensitive header handling is also ensured.

Fix #32, #178