### PR TITLE
✨ feat: add treaty error shorthand option

### DIFF
--- a/src/treaty2/index.ts
+++ b/src/treaty2/index.ts
@@ -9,15 +9,15 @@ import { EdenWS } from './ws'
 import { parseStringifiedValue } from '../utils/parsingUtils'
 
 const method = [
-	'get',
-	'post',
-	'put',
-	'delete',
-	'patch',
-	'options',
-	'head',
-	'connect',
-	'subscribe'
+    'get',
+    'post',
+    'put',
+    'delete',
+    'patch',
+    'options',
+    'head',
+    'connect',
+    'subscribe'
 ] as const
 
 const locals = ['localhost', '127.0.0.1', '0.0.0.0']
@@ -25,483 +25,482 @@ const locals = ['localhost', '127.0.0.1', '0.0.0.0']
 const isServer = typeof FileList === 'undefined'
 
 const isFile = (v: any) => {
-	if (isServer) return v instanceof Blob
+    if (isServer) return v instanceof Blob
 
-	return v instanceof FileList || v instanceof File
+    return v instanceof FileList || v instanceof File
 }
 
 // FormData is 1 level deep
 const hasFile = (obj: Record<string, any>) => {
-	if (!obj) return false
+    if (!obj) return false
 
-	for (const key in obj) {
-		if (isFile(obj[key])) return true
+    for (const key in obj) {
+        if (isFile(obj[key])) return true
 
-		if (Array.isArray(obj[key]) && (obj[key] as unknown[]).find(isFile))
-			return true
-	}
+        if (Array.isArray(obj[key]) && (obj[key] as unknown[]).find(isFile))
+            return true
+    }
 
-	return false
+    return false
 }
 
 const createNewFile = (v: File) =>
-	isServer
-		? v
-		: new Promise<File>((resolve) => {
-				const reader = new FileReader()
+    isServer
+        ? v
+        : new Promise<File>((resolve) => {
+              const reader = new FileReader()
 
-				reader.onload = () => {
-					const file = new File([reader.result!], v.name, {
-						lastModified: v.lastModified,
-						type: v.type
-					})
-					resolve(file)
-				}
+              reader.onload = () => {
+                  const file = new File([reader.result!], v.name, {
+                      lastModified: v.lastModified,
+                      type: v.type
+                  })
+                  resolve(file)
+              }
 
-				reader.readAsArrayBuffer(v)
-			})
+              reader.readAsArrayBuffer(v)
+          })
 
 const processHeaders = <ShouldThrow extends boolean>(
-	h: Treaty.Config<ShouldThrow>['headers'],
-	path: string,
-	options: RequestInit = {},
-	headers: Record<string, string> = {}
+    h: Treaty.Config<ShouldThrow>['headers'],
+    path: string,
+    options: RequestInit = {},
+    headers: Record<string, string> = {}
 ): Record<string, string> => {
-	if (Array.isArray(h)) {
-		for (const value of h)
-			if (!Array.isArray(value))
-				headers = processHeaders(value, path, options, headers)
-			else {
-				const key = value[0]
-				if (typeof key === 'string')
-					headers[key.toLowerCase()] = value[1] as string
-				else
-					for (const [k, value] of key)
-						headers[k.toLowerCase()] = value as string
-			}
+    if (Array.isArray(h)) {
+        for (const value of h)
+            if (!Array.isArray(value))
+                headers = processHeaders(value, path, options, headers)
+            else {
+                const key = value[0]
+                if (typeof key === 'string')
+                    headers[key.toLowerCase()] = value[1] as string
+                else
+                    for (const [k, value] of key)
+                        headers[k.toLowerCase()] = value as string
+            }
 
-		return headers
-	}
+        return headers
+    }
 
-	if (!h) return headers
+    if (!h) return headers
 
-	switch (typeof h) {
-		case 'function':
-			if (h instanceof Headers)
-				return processHeaders(h, path, options, headers)
+    switch (typeof h) {
+        case 'function':
+            if (h instanceof Headers)
+                return processHeaders(h, path, options, headers)
 
-			const v = h(path, options)
-			if (v) return processHeaders(v, path, options, headers)
-			return headers
+            const v = h(path, options)
+            if (v) return processHeaders(v, path, options, headers)
+            return headers
 
-		case 'object':
-			if (h instanceof Headers) {
-				h.forEach((value, key) => {
-					headers[key.toLowerCase()] = value
-				})
-				return headers
-			}
+        case 'object':
+            if (h instanceof Headers) {
+                h.forEach((value, key) => {
+                    headers[key.toLowerCase()] = value
+                })
+                return headers
+            }
 
-			for (const [key, value] of Object.entries(h))
-				headers[key.toLowerCase()] = value as string
+            for (const [key, value] of Object.entries(h))
+                headers[key.toLowerCase()] = value as string
 
-			return headers
+            return headers
 
-		default:
-			return headers
-	}
+        default:
+            return headers
+    }
 }
 
 export async function* streamResponse(response: Response) {
-	const body = response.body
+    const body = response.body
 
-	if (!body) return
+    if (!body) return
 
-	const reader = body.getReader()
-	const decoder = new TextDecoder()
+    const reader = body.getReader()
+    const decoder = new TextDecoder()
 
-	try {
-		while (true) {
-			const { done, value } = await reader.read()
-			if (done) break
+    try {
+        while (true) {
+            const { done, value } = await reader.read()
+            if (done) break
 
-			const data = decoder.decode(value)
+            const data = decoder.decode(value)
 
-			yield parseStringifiedValue(data)
-		}
-	} finally {
-		reader.releaseLock()
-	}
+            yield parseStringifiedValue(data)
+        }
+    } finally {
+        reader.releaseLock()
+    }
 }
 
 const createProxy = <ShouldThrow extends boolean>(
-	domain: string,
-	config: Treaty.Config<ShouldThrow>,
-	paths: string[] = [],
-	elysia?: Elysia<any, any, any, any, any, any>
+    domain: string,
+    config: Treaty.Config<ShouldThrow>,
+    paths: string[] = [],
+    elysia?: Elysia<any, any, any, any, any, any>
 ): any =>
-	new Proxy(() => {}, {
-		get(_, param: string): any {
-			return createProxy(
-				domain,
-				config,
-				param === 'index' ? paths : [...paths, param],
-				elysia
-			)
-		},
-		apply(_, __, [body, options]) {
-			if (
-				!body ||
-				options ||
-				(typeof body === 'object' && Object.keys(body).length !== 1) ||
-				method.includes(paths.at(-1) as any)
-			) {
-				const methodPaths = [...paths]
-				const method = methodPaths.pop()
-				const path = '/' + methodPaths.join('/')
+    new Proxy(() => {}, {
+        get(_, param: string): any {
+            return createProxy(
+                domain,
+                config,
+                param === 'index' ? paths : [...paths, param],
+                elysia
+            )
+        },
+        apply(_, __, [body, options]) {
+            if (
+                !body ||
+                options ||
+                (typeof body === 'object' && Object.keys(body).length !== 1) ||
+                method.includes(paths.at(-1) as any)
+            ) {
+                const methodPaths = [...paths]
+                const method = methodPaths.pop()
+                const path = '/' + methodPaths.join('/')
 
-				let {
-					fetcher = fetch,
-					headers,
-					onRequest,
-					onResponse,
-					fetch: conf
-				} = config
+                let {
+                    fetcher = fetch,
+                    headers,
+                    onRequest,
+                    onResponse,
+                    fetch: conf
+                } = config
 
-				const isGetOrHead =
-					method === 'get' ||
-					method === 'head' ||
-					method === 'subscribe'
+                const isGetOrHead =
+                    method === 'get' ||
+                    method === 'head' ||
+                    method === 'subscribe'
 
-				headers = processHeaders(headers, path, options)
+                headers = processHeaders(headers, path, options)
 
-				const query = isGetOrHead
-					? (body as Record<string, string | string[] | undefined>)
-							?.query
-					: options?.query
+                const query = isGetOrHead
+                    ? (body as Record<string, string | string[] | undefined>)
+                          ?.query
+                    : options?.query
 
-				let q = ''
-				if (query) {
-					const append = (key: string, value: string) => {
-						q +=
-							(q ? '&' : '?') +
-							`${encodeURIComponent(key)}=${encodeURIComponent(
-								value
-							)}`
-					}
+                let q = ''
+                if (query) {
+                    const append = (key: string, value: string) => {
+                        q +=
+                            (q ? '&' : '?') +
+                            `${encodeURIComponent(key)}=${encodeURIComponent(
+                                value
+                            )}`
+                    }
 
-					for (const [key, value] of Object.entries(query)) {
-						if (Array.isArray(value)) {
-							for (const v of value) append(key, v)
-							continue
-						}
+                    for (const [key, value] of Object.entries(query)) {
+                        if (Array.isArray(value)) {
+                            for (const v of value) append(key, v)
+                            continue
+                        }
 
-						if (typeof value === 'object') {
-							append(key, JSON.stringify(value))
-							continue
-						}
+                        if (typeof value === 'object') {
+                            append(key, JSON.stringify(value))
+                            continue
+                        }
 
+                        append(key, `${value}`)
+                    }
+                }
 
-						append(key, `${value}`)
-					}
-				}
+                if (method === 'subscribe') {
+                    const url =
+                        domain.replace(
+                            /^([^]+):\/\//,
+                            domain.startsWith('https://')
+                                ? 'wss://'
+                                : domain.startsWith('http://')
+                                ? 'ws://'
+                                : locals.find((v) =>
+                                      (domain as string).includes(v)
+                                  )
+                                ? 'ws://'
+                                : 'wss://'
+                        ) +
+                        path +
+                        q
 
-				if (method === 'subscribe') {
-					const url =
-						domain.replace(
-							/^([^]+):\/\//,
-							domain.startsWith('https://')
-								? 'wss://'
-								: domain.startsWith('http://')
-									? 'ws://'
-									: locals.find((v) =>
-												(domain as string).includes(v)
-										  )
-										? 'ws://'
-										: 'wss://'
-						) +
-						path +
-						q
+                    return new EdenWS(url)
+                }
 
-					return new EdenWS(url)
-				}
+                return (async () => {
+                    let fetchInit = {
+                        method: method?.toUpperCase(),
+                        body,
+                        ...conf,
+                        headers
+                    } satisfies FetchRequestInit
 
-				return (async () => {
-					let fetchInit = {
-						method: method?.toUpperCase(),
-						body,
-						...conf,
-						headers
-					} satisfies FetchRequestInit
+                    fetchInit.headers = {
+                        ...headers,
+                        ...processHeaders(
+                            // For GET and HEAD, options is moved to body (1st param)
+                            isGetOrHead ? body?.headers : options?.headers,
+                            path,
+                            fetchInit
+                        )
+                    }
 
-					fetchInit.headers = {
-						...headers,
-						...processHeaders(
-							// For GET and HEAD, options is moved to body (1st param)
-							isGetOrHead ? body?.headers : options?.headers,
-							path,
-							fetchInit
-						)
-					}
+                    const fetchOpts =
+                        isGetOrHead && typeof body === 'object'
+                            ? body.fetch
+                            : options?.fetch
 
-					const fetchOpts =
-						isGetOrHead && typeof body === 'object'
-							? body.fetch
-							: options?.fetch
+                    fetchInit = {
+                        ...fetchInit,
+                        ...fetchOpts
+                    }
 
-					fetchInit = {
-						...fetchInit,
-						...fetchOpts
-					}
+                    if (isGetOrHead) delete fetchInit.body
 
-					if (isGetOrHead) delete fetchInit.body
+                    if (onRequest) {
+                        if (!Array.isArray(onRequest)) onRequest = [onRequest]
 
-					if (onRequest) {
-						if (!Array.isArray(onRequest)) onRequest = [onRequest]
+                        for (const value of onRequest) {
+                            const temp = await value(path, fetchInit)
 
-						for (const value of onRequest) {
-							const temp = await value(path, fetchInit)
+                            if (typeof temp === 'object')
+                                fetchInit = {
+                                    ...fetchInit,
+                                    ...temp,
+                                    headers: {
+                                        ...fetchInit.headers,
+                                        ...processHeaders(
+                                            temp.headers,
+                                            path,
+                                            fetchInit
+                                        )
+                                    }
+                                }
+                        }
+                    }
 
-							if (typeof temp === 'object')
-								fetchInit = {
-									...fetchInit,
-									...temp,
-									headers: {
-										...fetchInit.headers,
-										...processHeaders(
-											temp.headers,
-											path,
-											fetchInit
-										)
-									}
-								}
-						}
-					}
+                    // ? Duplicate because end-user might add a body in onRequest
+                    if (isGetOrHead) delete fetchInit.body
 
-					// ? Duplicate because end-user might add a body in onRequest
-					if (isGetOrHead) delete fetchInit.body
+                    if (hasFile(body)) {
+                        const formData = new FormData()
 
-					if (hasFile(body)) {
-						const formData = new FormData()
+                        // FormData is 1 level deep
+                        for (const [key, field] of Object.entries(
+                            fetchInit.body
+                        )) {
+                            if (isServer) {
+                                formData.append(key, field as any)
 
-						// FormData is 1 level deep
-						for (const [key, field] of Object.entries(
-							fetchInit.body
-						)) {
-							if (isServer) {
-								formData.append(key, field as any)
+                                continue
+                            }
 
-								continue
-							}
+                            if (field instanceof File) {
+                                formData.append(
+                                    key,
+                                    await createNewFile(field as any)
+                                )
 
-							if (field instanceof File) {
-								formData.append(
-									key,
-									await createNewFile(field as any)
-								)
+                                continue
+                            }
 
-								continue
-							}
+                            if (field instanceof FileList) {
+                                for (let i = 0; i < field.length; i++)
+                                    formData.append(
+                                        key as any,
+                                        await createNewFile((field as any)[i])
+                                    )
 
-							if (field instanceof FileList) {
-								for (let i = 0; i < field.length; i++)
-									formData.append(
-										key as any,
-										await createNewFile((field as any)[i])
-									)
+                                continue
+                            }
 
-								continue
-							}
+                            if (Array.isArray(field)) {
+                                for (let i = 0; i < field.length; i++) {
+                                    const value = (field as any)[i]
 
-							if (Array.isArray(field)) {
-								for (let i = 0; i < field.length; i++) {
-									const value = (field as any)[i]
+                                    formData.append(
+                                        key as any,
+                                        value instanceof File
+                                            ? await createNewFile(value)
+                                            : value
+                                    )
+                                }
 
-									formData.append(
-										key as any,
-										value instanceof File
-											? await createNewFile(value)
-											: value
-									)
-								}
+                                continue
+                            }
 
-								continue
-							}
+                            formData.append(key, field as string)
+                        }
 
-							formData.append(key, field as string)
-						}
+                        // We don't do this because we need to let the browser set the content type with the correct boundary
+                        // fetchInit.headers['content-type'] = 'multipart/form-data'
+                        fetchInit.body = formData
+                    } else if (typeof body === 'object') {
+                        ;(fetchInit.headers as Record<string, string>)[
+                            'content-type'
+                        ] = 'application/json'
 
-						// We don't do this because we need to let the browser set the content type with the correct boundary
-						// fetchInit.headers['content-type'] = 'multipart/form-data'
-						fetchInit.body = formData
-					} else if (typeof body === 'object') {
-						;(fetchInit.headers as Record<string, string>)[
-							'content-type'
-						] = 'application/json'
+                        fetchInit.body = JSON.stringify(body)
+                    } else if (body !== undefined && body !== null) {
+                        ;(fetchInit.headers as Record<string, string>)[
+                            'content-type'
+                        ] = 'text/plain'
+                    }
 
-						fetchInit.body = JSON.stringify(body)
-					} else if (body !== undefined && body !== null) {
-						;(fetchInit.headers as Record<string, string>)[
-							'content-type'
-						] = 'text/plain'
-					}
+                    if (isGetOrHead) delete fetchInit.body
 
-					if (isGetOrHead) delete fetchInit.body
+                    if (onRequest) {
+                        if (!Array.isArray(onRequest)) onRequest = [onRequest]
 
-					if (onRequest) {
-						if (!Array.isArray(onRequest)) onRequest = [onRequest]
+                        for (const value of onRequest) {
+                            const temp = await value(path, fetchInit)
 
-						for (const value of onRequest) {
-							const temp = await value(path, fetchInit)
+                            if (typeof temp === 'object')
+                                fetchInit = {
+                                    ...fetchInit,
+                                    ...temp,
+                                    headers: {
+                                        ...fetchInit.headers,
+                                        ...processHeaders(
+                                            temp.headers,
+                                            path,
+                                            fetchInit
+                                        )
+                                    } as Record<string, string>
+                                }
+                        }
+                    }
 
-							if (typeof temp === 'object')
-								fetchInit = {
-									...fetchInit,
-									...temp,
-									headers: {
-										...fetchInit.headers,
-										...processHeaders(
-											temp.headers,
-											path,
-											fetchInit
-										)
-									} as Record<string, string>
-								}
-						}
-					}
+                    const url = domain + path + q
+                    const response = await (elysia?.handle(
+                        new Request(url, fetchInit)
+                    ) ?? fetcher!(url, fetchInit))
 
-					const url = domain + path + q
-					const response = await (elysia?.handle(
-						new Request(url, fetchInit)
-					) ?? fetcher!(url, fetchInit))
+                    // @ts-ignore
+                    let data = null
+                    let error = null
 
-					// @ts-ignore
-					let data = null
-					let error = null
+                    if (onResponse) {
+                        if (!Array.isArray(onResponse))
+                            onResponse = [onResponse]
 
-					if (onResponse) {
-						if (!Array.isArray(onResponse))
-							onResponse = [onResponse]
+                        for (const value of onResponse)
+                            try {
+                                const temp = await value(response.clone())
 
-						for (const value of onResponse)
-							try {
-								const temp = await value(response.clone())
+                                if (temp !== undefined && temp !== null) {
+                                    data = temp
+                                    break
+                                }
+                            } catch (err) {
+                                if (err instanceof EdenFetchError) error = err
+                                else error = new EdenFetchError(422, err)
 
-								if (temp !== undefined && temp !== null) {
-									data = temp
-									break
-								}
-							} catch (err) {
-								if (err instanceof EdenFetchError) error = err
-								else error = new EdenFetchError(422, err)
+                                break
+                            }
+                    }
 
-								break
-							}
-					}
+                    if (data !== null) {
+                        if (config.throw) return data
+                        return {
+                            data,
+                            error,
+                            response,
+                            status: response.status,
+                            headers: response.headers
+                        }
+                    }
 
-					if (data !== null) {
-						if(config.shouldThrow) return data
-						return {
-							data,
-							error,
-							response,
-							status: response.status,
-							headers: response.headers
-						}
-					}
+                    switch (
+                        response.headers.get('Content-Type')?.split(';')[0]
+                    ) {
+                        case 'text/event-stream':
+                            data = streamResponse(response)
+                            break
 
-					switch (
-						response.headers.get('Content-Type')?.split(';')[0]
-					) {
-						case 'text/event-stream':
-							data = streamResponse(response)
-							break
+                        case 'application/json':
+                            data = await response.json()
+                            break
+                        case 'application/octet-stream':
+                            data = await response.arrayBuffer()
+                            break
 
-						case 'application/json':
-							data = await response.json()
-							break
-						case 'application/octet-stream':
-							data = await response.arrayBuffer()
-							break
+                        case 'multipart/form-data':
+                            const temp = await response.formData()
 
-						case 'multipart/form-data':
-							const temp = await response.formData()
+                            data = {}
+                            temp.forEach((value, key) => {
+                                // @ts-ignore
+                                data[key] = value
+                            })
 
-							data = {}
-							temp.forEach((value, key) => {
-								// @ts-ignore
-								data[key] = value
-							})
+                            break
 
-							break
+                        default:
+                            data = await response
+                                .text()
+                                .then(parseStringifiedValue)
+                    }
 
-						default:
-							data = await response
-								.text()
-								.then(parseStringifiedValue)
-					}
+                    if (response.status >= 300 || response.status < 200) {
+                        error = new EdenFetchError(response.status, data)
+                        data = null
+                    }
 
-					if (response.status >= 300 || response.status < 200) {
-						error = new EdenFetchError(response.status, data)
-						data = null
-					}
-
-					if (config.shouldThrow) {
+                    if (config.throw) {
                         if (error) {
                             throw error
                         }
                         return data
                     }
 
-					return {
-						data,
-						error,
-						response,
-						status: response.status,
-						headers: response.headers
-					}
-				})()
-			}
+                    return {
+                        data,
+                        error,
+                        response,
+                        status: response.status,
+                        headers: response.headers
+                    }
+                })()
+            }
 
-			if (typeof body === 'object')
-				return createProxy(
-					domain,
-					config,
-					[...paths, Object.values(body)[0] as string],
-					elysia
-				)
+            if (typeof body === 'object')
+                return createProxy(
+                    domain,
+                    config,
+                    [...paths, Object.values(body)[0] as string],
+                    elysia
+                )
 
-			return createProxy(domain, config, paths)
-		}
-	}) as any
+            return createProxy(domain, config, paths)
+        }
+    }) as any
 
 export const treaty = <
-	const App extends Elysia<any, any, any, any, any, any, any>,
-	ShouldThrow extends boolean = false
+    const App extends Elysia<any, any, any, any, any, any, any>,
+    ShouldThrow extends boolean = false
 >(
-	domain: string | App,
-	config: Treaty.Config<ShouldThrow> = {}
+    domain: string | App,
+    config: Treaty.Config<ShouldThrow> = {}
 ): Treaty.Create<App, ShouldThrow> => {
-	if (typeof domain === 'string') {
-		if (!config.keepDomain) {
-			if (!domain.includes('://'))
-				domain =
-					(locals.find((v) => (domain as string).includes(v))
-						? 'http://'
-						: 'https://') + domain
+    if (typeof domain === 'string') {
+        if (!config.keepDomain) {
+            if (!domain.includes('://'))
+                domain =
+                    (locals.find((v) => (domain as string).includes(v))
+                        ? 'http://'
+                        : 'https://') + domain
 
-			if (domain.endsWith('/')) domain = domain.slice(0, -1)
-		}
+            if (domain.endsWith('/')) domain = domain.slice(0, -1)
+        }
 
-		return createProxy(domain, config)
-	}
+        return createProxy(domain, config)
+    }
 
-	if (typeof window !== 'undefined')
-		console.warn(
-			'Elysia instance server found on client side, this is not recommended for security reason. Use generic type instead.'
-		)
+    if (typeof window !== 'undefined')
+        console.warn(
+            'Elysia instance server found on client side, this is not recommended for security reason. Use generic type instead.'
+        )
 
-	return createProxy('http://e.ly', config, [], domain)
+    return createProxy('http://e.ly', config, [], domain)
 }
 
 export type { Treaty }

--- a/src/treaty2/types.ts
+++ b/src/treaty2/types.ts
@@ -186,7 +186,25 @@ export namespace Treaty {
 		>
 		onResponse?: MaybeArray<(response: Response) => MaybePromise<unknown>>
 		keepDomain?: boolean,
-		shouldThrow?: ShouldThrow
+		/**
+		 * If set to true the calls made by this client will throw an actual error and will not return a response object
+		 * in case of an unsuccessful request.
+		 * Setting this to true reduces the complexity in usage but increases hides away the details of the request.
+		 * @default false
+		 * 
+		 * @example
+		 * ```ts
+		 * const userResult = await backend.auth["upsert-self"].post();
+		 * if (userResult.error) {
+		 *   throw userResult.error;
+		 * }
+		 * const user = userResult.data;
+		 *
+		 * // becomes
+		 * const user = await backend.auth["upsert-self"].post();
+		 * ```
+		 */
+		throw?: ShouldThrow
 	}
 
 	// type UnwrapAwaited<T extends Record<number, unknown>> = {

--- a/test/treaty2.test.ts
+++ b/test/treaty2.test.ts
@@ -4,649 +4,649 @@ import { treaty } from '../src'
 import { describe, expect, it, beforeAll, afterAll, mock } from 'bun:test'
 
 const randomObject = {
-	a: 'a',
-	b: 2,
-	c: true,
-	d: false,
-	e: null,
-	f: new Date(0)
+    a: 'a',
+    b: 2,
+    c: true,
+    d: false,
+    e: null,
+    f: new Date(0)
 }
 const randomArray = [
-	'a',
-	2,
-	true,
-	false,
-	null,
-	new Date(0),
-	{ a: 'a', b: 2, c: true, d: false, e: null, f: new Date(0) }
+    'a',
+    2,
+    true,
+    false,
+    null,
+    new Date(0),
+    { a: 'a', b: 2, c: true, d: false, e: null, f: new Date(0) }
 ]
 const websocketPayloads = [
-	// strings
-	'str',
-	// numbers
-	1,
-	1.2,
-	// booleans
-	true,
-	false,
-	// null values
-	null,
-	// A date
-	new Date(0),
-	// A random object
-	randomObject,
-	// A random array
-	randomArray
+    // strings
+    'str',
+    // numbers
+    1,
+    1.2,
+    // booleans
+    true,
+    false,
+    // null values
+    null,
+    // A date
+    new Date(0),
+    // A random object
+    randomObject,
+    // A random array
+    randomArray
 ] as const
 
 const app = new Elysia()
-	.get('/', 'a')
-	.post('/', 'a')
-	.get('/number', () => 1)
-	.get('/true', () => true)
-	.get('/false', () => false)
-	.post('/array', ({ body }) => body, {
-		body: t.Array(t.String())
-	})
-	.post('/mirror', ({ body }) => body)
-	.post('/body', ({ body }) => body, {
-		body: t.String()
-	})
-	.delete('/empty', ({ body }) => ({ body: body ?? null }))
-	.post('/deep/nested/mirror', ({ body }) => body, {
-		body: t.Object({
-			username: t.String(),
-			password: t.String()
-		})
-	})
-	.get('/query', ({ query }) => query, {
-		query: t.Object({
-			username: t.String()
-		})
-	})
-	.get('/queries', ({ query }) => query, {
-		query: t.Object({
-			username: t.String(),
-			alias: t.Literal('Kristen')
-		})
-	})
-	.post('/queries', ({ query }) => query, {
-		query: t.Object({
-			username: t.String(),
-			alias: t.Literal('Kristen')
-		})
-	})
-	.head('/queries', ({ query }) => query, {
-		query: t.Object({
-			username: t.String(),
-			alias: t.Literal('Kristen')
-		})
-	})
-	.group('/nested', (app) => app.guard((app) => app.get('/data', () => 'hi')))
-	.get('/error', ({ error }) => error("I'm a teapot", 'Kirifuji Nagisa'), {
-		response: {
-			200: t.Void(),
-			418: t.Literal('Kirifuji Nagisa'),
-			420: t.Literal('Snoop Dogg')
-		}
-	})
-	.get(
-		'/headers',
-		({ headers: { username, alias } }) => ({ username, alias }),
-		{
-			headers: t.Object({
-				username: t.String(),
-				alias: t.Literal('Kristen')
-			})
-		}
-	)
-	.post(
-		'/headers',
-		({ headers: { username, alias } }) => ({ username, alias }),
-		{
-			headers: t.Object({
-				username: t.String(),
-				alias: t.Literal('Kristen')
-			})
-		}
-	)
-	.get(
-		'/headers-custom',
-		({ headers, headers: { username, alias } }) => ({
-			username,
-			alias,
-			'x-custom': headers['x-custom']
-		}),
-		{
-			headers: t.Object({
-				username: t.String(),
-				alias: t.Literal('Kristen'),
-				'x-custom': t.Optional(t.Literal('custom'))
-			})
-		}
-	)
-	.post('/date', ({ body: { date } }) => date, {
-		body: t.Object({
-			date: t.Date()
-		})
-	})
-	.get('/dateObject', () => ({ date: new Date() }))
-	.get('/redirect', ({ redirect }) => redirect('http://localhost:8083/true'))
-	.post(
-		'/redirect',
-		({ redirect }) => redirect('http://localhost:8083/true'),
-		{
-			body: t.Object({
-				username: t.String()
-			})
-		}
-	)
-	.get('/formdata', () =>
-		form({
-			image: Bun.file('./test/kyuukurarin.mp4')
-		})
-	)
-	.ws('/json-serialization-deserialization', {
-		open: async (ws) => {
-			for (const item of websocketPayloads) {
-				ws.send(item)
-			}
-			ws.close()
-		}
-	})
-	.get('/stream', function* stream() {
-		yield 'a'
-		yield 'b'
-		yield 'c'
-	})
-	.get('/stream-async', async function* stream() {
-		yield 'a'
-		yield 'b'
-		yield 'c'
-	})
-	.get('/stream-return', function* stream() {
-		return 'a'
-	})
-	.get('/stream-return-async', function* stream() {
-		return 'a'
-	})
-	.get('/id/:id?', ({ params: { id = 'unknown' } }) => id)
+    .get('/', 'a')
+    .post('/', 'a')
+    .get('/number', () => 1)
+    .get('/true', () => true)
+    .get('/false', () => false)
+    .post('/array', ({ body }) => body, {
+        body: t.Array(t.String())
+    })
+    .post('/mirror', ({ body }) => body)
+    .post('/body', ({ body }) => body, {
+        body: t.String()
+    })
+    .delete('/empty', ({ body }) => ({ body: body ?? null }))
+    .post('/deep/nested/mirror', ({ body }) => body, {
+        body: t.Object({
+            username: t.String(),
+            password: t.String()
+        })
+    })
+    .get('/query', ({ query }) => query, {
+        query: t.Object({
+            username: t.String()
+        })
+    })
+    .get('/queries', ({ query }) => query, {
+        query: t.Object({
+            username: t.String(),
+            alias: t.Literal('Kristen')
+        })
+    })
+    .post('/queries', ({ query }) => query, {
+        query: t.Object({
+            username: t.String(),
+            alias: t.Literal('Kristen')
+        })
+    })
+    .head('/queries', ({ query }) => query, {
+        query: t.Object({
+            username: t.String(),
+            alias: t.Literal('Kristen')
+        })
+    })
+    .group('/nested', (app) => app.guard((app) => app.get('/data', () => 'hi')))
+    .get('/error', ({ error }) => error("I'm a teapot", 'Kirifuji Nagisa'), {
+        response: {
+            200: t.Void(),
+            418: t.Literal('Kirifuji Nagisa'),
+            420: t.Literal('Snoop Dogg')
+        }
+    })
+    .get(
+        '/headers',
+        ({ headers: { username, alias } }) => ({ username, alias }),
+        {
+            headers: t.Object({
+                username: t.String(),
+                alias: t.Literal('Kristen')
+            })
+        }
+    )
+    .post(
+        '/headers',
+        ({ headers: { username, alias } }) => ({ username, alias }),
+        {
+            headers: t.Object({
+                username: t.String(),
+                alias: t.Literal('Kristen')
+            })
+        }
+    )
+    .get(
+        '/headers-custom',
+        ({ headers, headers: { username, alias } }) => ({
+            username,
+            alias,
+            'x-custom': headers['x-custom']
+        }),
+        {
+            headers: t.Object({
+                username: t.String(),
+                alias: t.Literal('Kristen'),
+                'x-custom': t.Optional(t.Literal('custom'))
+            })
+        }
+    )
+    .post('/date', ({ body: { date } }) => date, {
+        body: t.Object({
+            date: t.Date()
+        })
+    })
+    .get('/dateObject', () => ({ date: new Date() }))
+    .get('/redirect', ({ redirect }) => redirect('http://localhost:8083/true'))
+    .post(
+        '/redirect',
+        ({ redirect }) => redirect('http://localhost:8083/true'),
+        {
+            body: t.Object({
+                username: t.String()
+            })
+        }
+    )
+    .get('/formdata', () =>
+        form({
+            image: Bun.file('./test/kyuukurarin.mp4')
+        })
+    )
+    .ws('/json-serialization-deserialization', {
+        open: async (ws) => {
+            for (const item of websocketPayloads) {
+                ws.send(item)
+            }
+            ws.close()
+        }
+    })
+    .get('/stream', function* stream() {
+        yield 'a'
+        yield 'b'
+        yield 'c'
+    })
+    .get('/stream-async', async function* stream() {
+        yield 'a'
+        yield 'b'
+        yield 'c'
+    })
+    .get('/stream-return', function* stream() {
+        return 'a'
+    })
+    .get('/stream-return-async', function* stream() {
+        return 'a'
+    })
+    .get('/id/:id?', ({ params: { id = 'unknown' } }) => id)
 
 const client = treaty(app)
-const throwingClient = treaty(app, { shouldThrow: true })
+const throwingClient = treaty(app, { throw: true })
 
 describe('Treaty2', () => {
-	it('get index', async () => {
-		const { data, error } = await client.index.get()
+    it('get index', async () => {
+        const { data, error } = await client.index.get()
 
-		expect(data).toBe('a')
-		expect(error).toBeNull()
-	})
+        expect(data).toBe('a')
+        expect(error).toBeNull()
+    })
 
-	it('post index', async () => {
-		const { data, error } = await client.index.post()
+    it('post index', async () => {
+        const { data, error } = await client.index.post()
 
-		expect(data).toBe('a')
-		expect(error).toBeNull()
-	})
+        expect(data).toBe('a')
+        expect(error).toBeNull()
+    })
 
-	it('parse number', async () => {
-		const { data } = await client.number.get()
+    it('parse number', async () => {
+        const { data } = await client.number.get()
 
-		expect(data).toEqual(1)
-	})
+        expect(data).toEqual(1)
+    })
 
-	it('parse true', async () => {
-		const { data } = await client.true.get()
+    it('parse true', async () => {
+        const { data } = await client.true.get()
 
-		expect(data).toEqual(true)
-	})
+        expect(data).toEqual(true)
+    })
 
-	it('parse false', async () => {
-		const { data } = await client.false.get()
+    it('parse false', async () => {
+        const { data } = await client.false.get()
 
-		expect(data).toEqual(false)
-	})
+        expect(data).toEqual(false)
+    })
 
-	it.todo('parse object with date', async () => {
-		const { data } = await client.dateObject.get()
+    it.todo('parse object with date', async () => {
+        const { data } = await client.dateObject.get()
 
-		expect(data?.date).toBeInstanceOf(Date)
-	})
+        expect(data?.date).toBeInstanceOf(Date)
+    })
 
-	it('post array', async () => {
-		const { data } = await client.array.post(['a', 'b'])
+    it('post array', async () => {
+        const { data } = await client.array.post(['a', 'b'])
 
-		expect(data).toEqual(['a', 'b'])
-	})
+        expect(data).toEqual(['a', 'b'])
+    })
 
-	it('post body', async () => {
-		const { data } = await client.body.post('a')
+    it('post body', async () => {
+        const { data } = await client.body.post('a')
 
-		expect(data).toEqual('a')
-	})
+        expect(data).toEqual('a')
+    })
 
-	it('post mirror', async () => {
-		const body = { username: 'A', password: 'B' }
+    it('post mirror', async () => {
+        const body = { username: 'A', password: 'B' }
 
-		const { data } = await client.mirror.post(body)
+        const { data } = await client.mirror.post(body)
 
-		expect(data).toEqual(body)
-	})
+        expect(data).toEqual(body)
+    })
 
-	it('delete empty', async () => {
-		const { data } = await client.empty.delete()
+    it('delete empty', async () => {
+        const { data } = await client.empty.delete()
 
-		expect(data).toEqual({ body: null })
-	})
+        expect(data).toEqual({ body: null })
+    })
 
-	it('post deep nested mirror', async () => {
-		const body = { username: 'A', password: 'B' }
+    it('post deep nested mirror', async () => {
+        const body = { username: 'A', password: 'B' }
 
-		const { data } = await client.deep.nested.mirror.post(body)
+        const { data } = await client.deep.nested.mirror.post(body)
 
-		expect(data).toEqual(body)
-	})
+        expect(data).toEqual(body)
+    })
 
-	it('get query', async () => {
-		const query = { username: 'A' }
+    it('get query', async () => {
+        const query = { username: 'A' }
 
-		const { data } = await client.query.get({
-			query
-		})
+        const { data } = await client.query.get({
+            query
+        })
 
-		expect(data).toEqual(query)
-	})
+        expect(data).toEqual(query)
+    })
 
-	it('get queries', async () => {
-		const query = { username: 'A', alias: 'Kristen' } as const
+    it('get queries', async () => {
+        const query = { username: 'A', alias: 'Kristen' } as const
 
-		const { data } = await client.queries.get({
-			query
-		})
+        const { data } = await client.queries.get({
+            query
+        })
 
-		expect(data).toEqual(query)
-	})
+        expect(data).toEqual(query)
+    })
 
-	it('post queries', async () => {
-		const query = { username: 'A', alias: 'Kristen' } as const
+    it('post queries', async () => {
+        const query = { username: 'A', alias: 'Kristen' } as const
 
-		const { data } = await client.queries.post(null, {
-			query
-		})
+        const { data } = await client.queries.post(null, {
+            query
+        })
 
-		expect(data).toEqual(query)
-	})
-
-	it('head queries', async () => {
-		const query = { username: 'A', alias: 'Kristen' } as const
-
-		const { data } = await client.queries.post(null, {
-			query
-		})
-
-		expect(data).toEqual(query)
-	})
-
-	it('get nested data', async () => {
-		const { data } = await client.nested.data.get()
-
-		expect(data).toEqual('hi')
-	})
-
-	it('handle error', async () => {
-		const { data, error } = await client.error.get()
-
-		let value
-
-		if (error)
-			switch (error.status) {
-				case 418:
-					value = error.value
-					break
-
-				case 420:
-					value = error.value
-					break
-			}
-
-		expect(data).toBeNull()
-		expect(value).toEqual('Kirifuji Nagisa')
-	})
-
-	it('get headers', async () => {
-		const headers = { username: 'A', alias: 'Kristen' } as const
-
-		const { data } = await client.headers.get({
-			headers
-		})
-
-		expect(data).toEqual(headers)
-	})
-
-	it('post headers', async () => {
-		const headers = { username: 'A', alias: 'Kristen' } as const
-
-		const { data } = await client.headers.post(null, {
-			headers
-		})
-
-		expect(data).toEqual(headers)
-	})
-
-	it('handle interception', async () => {
-		const client = treaty(app, {
-			onRequest(path) {
-				if (path === '/headers-custom')
-					return {
-						headers: {
-							'x-custom': 'custom'
-						}
-					}
-			},
-			async onResponse(response) {
-				return { intercepted: true, data: await response.json() }
-			}
-		})
-
-		const headers = { username: 'a', alias: 'Kristen' } as const
-
-		const { data } = await client['headers-custom'].get({
-			headers
-		})
-
-		expect(data).toEqual({
-			// @ts-expect-error
-			intercepted: true,
-			data: {
-				...headers,
-				'x-custom': 'custom'
-			}
-		})
-	})
-
-	it('handle interception array', async () => {
-		const client = treaty(app, {
-			onRequest: [
-				() => ({
-					headers: {
-						'x-custom': 'a'
-					}
-				}),
-				() => ({
-					headers: {
-						'x-custom': 'custom'
-					}
-				})
-			],
-			onResponse: [
-				() => {},
-				async (response) => {
-					return { intercepted: true, data: await response.json() }
-				}
-			]
-		})
-
-		const headers = { username: 'a', alias: 'Kristen' } as const
-
-		const { data } = await client['headers-custom'].get({
-			headers
-		})
-
-		expect(data).toEqual({
-			// @ts-expect-error
-			intercepted: true,
-			data: {
-				...headers,
-				'x-custom': 'custom'
-			}
-		})
-	})
-
-	it('accept headers configuration', async () => {
-		const client = treaty(app, {
-			headers(path) {
-				if (path === '/headers-custom')
-					return {
-						'x-custom': 'custom'
-					}
-			},
-			async onResponse(response) {
-				return { intercepted: true, data: await response.json() }
-			}
-		})
-
-		const headers = { username: 'a', alias: 'Kristen' } as const
-
-		const { data } = await client['headers-custom'].get({
-			headers
-		})
-
-		expect(data).toEqual({
-			// @ts-expect-error
-			intercepted: true,
-			data: {
-				...headers,
-				'x-custom': 'custom'
-			}
-		})
-	})
-
-	it('accept headers configuration array', async () => {
-		const client = treaty(app, {
-			headers: [
-				(path) => {
-					if (path === '/headers-custom')
-						return {
-							'x-custom': 'custom'
-						}
-				}
-			],
-			async onResponse(response) {
-				return { intercepted: true, data: await response.json() }
-			}
-		})
-
-		const headers = { username: 'a', alias: 'Kristen' } as const
-
-		const { data } = await client['headers-custom'].get({
-			headers
-		})
-
-		expect(data).toEqual({
-			// @ts-expect-error
-			intercepted: true,
-			data: {
-				...headers,
-				'x-custom': 'custom'
-			}
-		})
-	})
-
-	it('send date', async () => {
-		const { data } = await client.date.post({ date: new Date() })
-
-		expect(data).toBeInstanceOf(Date)
-	})
-
-	it('redirect should set location header', async () => {
-		const { headers, status } = await client['redirect'].get({
-			fetch: {
-				redirect: 'manual'
-			}
-		})
-		expect(status).toEqual(302)
-		expect(new Headers(headers).get('location')).toEqual(
-			'http://localhost:8083/true'
-		)
-	})
-
-	it('generator return stream', async () => {
-		const a = await client.stream.get()
-		const result = <string[]>[]
-
-		for await (const chunk of a.data!) result.push(chunk)
-
-		expect(result).toEqual(['a', 'b', 'c'])
-	})
-
-	it('generator return async stream', async () => {
-		const a = await client['stream-async'].get()
-		const result = <string[]>[]
-
-		for await (const chunk of a.data!) result.push(chunk)
-
-		expect(result).toEqual(['a', 'b', 'c'])
-	})
-
-	it('generator return value', async () => {
-		const a = await client['stream-return'].get()
-
-		expect(a.data).toBe('a')
-	})
-
-	it('generator return async value', async () => {
-		const a = await client['stream-return-async'].get()
-
-		expect(a.data).toBe('a')
-	})
-
-	it('handle optional params', async () => {
-		const data = await Promise.all([
-			client.id.get(),
-			client.id({ id: 'salty' }).get()
-		])
-		expect(data.map((x) => x.data)).toEqual(['unknown', 'salty'])
-	})
+        expect(data).toEqual(query)
+    })
+
+    it('head queries', async () => {
+        const query = { username: 'A', alias: 'Kristen' } as const
+
+        const { data } = await client.queries.post(null, {
+            query
+        })
+
+        expect(data).toEqual(query)
+    })
+
+    it('get nested data', async () => {
+        const { data } = await client.nested.data.get()
+
+        expect(data).toEqual('hi')
+    })
+
+    it('handle error', async () => {
+        const { data, error } = await client.error.get()
+
+        let value
+
+        if (error)
+            switch (error.status) {
+                case 418:
+                    value = error.value
+                    break
+
+                case 420:
+                    value = error.value
+                    break
+            }
+
+        expect(data).toBeNull()
+        expect(value).toEqual('Kirifuji Nagisa')
+    })
+
+    it('get headers', async () => {
+        const headers = { username: 'A', alias: 'Kristen' } as const
+
+        const { data } = await client.headers.get({
+            headers
+        })
+
+        expect(data).toEqual(headers)
+    })
+
+    it('post headers', async () => {
+        const headers = { username: 'A', alias: 'Kristen' } as const
+
+        const { data } = await client.headers.post(null, {
+            headers
+        })
+
+        expect(data).toEqual(headers)
+    })
+
+    it('handle interception', async () => {
+        const client = treaty(app, {
+            onRequest(path) {
+                if (path === '/headers-custom')
+                    return {
+                        headers: {
+                            'x-custom': 'custom'
+                        }
+                    }
+            },
+            async onResponse(response) {
+                return { intercepted: true, data: await response.json() }
+            }
+        })
+
+        const headers = { username: 'a', alias: 'Kristen' } as const
+
+        const { data } = await client['headers-custom'].get({
+            headers
+        })
+
+        expect(data).toEqual({
+            // @ts-expect-error
+            intercepted: true,
+            data: {
+                ...headers,
+                'x-custom': 'custom'
+            }
+        })
+    })
+
+    it('handle interception array', async () => {
+        const client = treaty(app, {
+            onRequest: [
+                () => ({
+                    headers: {
+                        'x-custom': 'a'
+                    }
+                }),
+                () => ({
+                    headers: {
+                        'x-custom': 'custom'
+                    }
+                })
+            ],
+            onResponse: [
+                () => {},
+                async (response) => {
+                    return { intercepted: true, data: await response.json() }
+                }
+            ]
+        })
+
+        const headers = { username: 'a', alias: 'Kristen' } as const
+
+        const { data } = await client['headers-custom'].get({
+            headers
+        })
+
+        expect(data).toEqual({
+            // @ts-expect-error
+            intercepted: true,
+            data: {
+                ...headers,
+                'x-custom': 'custom'
+            }
+        })
+    })
+
+    it('accept headers configuration', async () => {
+        const client = treaty(app, {
+            headers(path) {
+                if (path === '/headers-custom')
+                    return {
+                        'x-custom': 'custom'
+                    }
+            },
+            async onResponse(response) {
+                return { intercepted: true, data: await response.json() }
+            }
+        })
+
+        const headers = { username: 'a', alias: 'Kristen' } as const
+
+        const { data } = await client['headers-custom'].get({
+            headers
+        })
+
+        expect(data).toEqual({
+            // @ts-expect-error
+            intercepted: true,
+            data: {
+                ...headers,
+                'x-custom': 'custom'
+            }
+        })
+    })
+
+    it('accept headers configuration array', async () => {
+        const client = treaty(app, {
+            headers: [
+                (path) => {
+                    if (path === '/headers-custom')
+                        return {
+                            'x-custom': 'custom'
+                        }
+                }
+            ],
+            async onResponse(response) {
+                return { intercepted: true, data: await response.json() }
+            }
+        })
+
+        const headers = { username: 'a', alias: 'Kristen' } as const
+
+        const { data } = await client['headers-custom'].get({
+            headers
+        })
+
+        expect(data).toEqual({
+            // @ts-expect-error
+            intercepted: true,
+            data: {
+                ...headers,
+                'x-custom': 'custom'
+            }
+        })
+    })
+
+    it('send date', async () => {
+        const { data } = await client.date.post({ date: new Date() })
+
+        expect(data).toBeInstanceOf(Date)
+    })
+
+    it('redirect should set location header', async () => {
+        const { headers, status } = await client['redirect'].get({
+            fetch: {
+                redirect: 'manual'
+            }
+        })
+        expect(status).toEqual(302)
+        expect(new Headers(headers).get('location')).toEqual(
+            'http://localhost:8083/true'
+        )
+    })
+
+    it('generator return stream', async () => {
+        const a = await client.stream.get()
+        const result = <string[]>[]
+
+        for await (const chunk of a.data!) result.push(chunk)
+
+        expect(result).toEqual(['a', 'b', 'c'])
+    })
+
+    it('generator return async stream', async () => {
+        const a = await client['stream-async'].get()
+        const result = <string[]>[]
+
+        for await (const chunk of a.data!) result.push(chunk)
+
+        expect(result).toEqual(['a', 'b', 'c'])
+    })
+
+    it('generator return value', async () => {
+        const a = await client['stream-return'].get()
+
+        expect(a.data).toBe('a')
+    })
+
+    it('generator return async value', async () => {
+        const a = await client['stream-return-async'].get()
+
+        expect(a.data).toBe('a')
+    })
+
+    it('handle optional params', async () => {
+        const data = await Promise.all([
+            client.id.get(),
+            client.id({ id: 'salty' }).get()
+        ])
+        expect(data.map((x) => x.data)).toEqual(['unknown', 'salty'])
+    })
 })
 
 describe('Treaty2 - Using endpoint URL', () => {
-	const treatyApp = treaty<typeof app>('http://localhost:8083')
+    const treatyApp = treaty<typeof app>('http://localhost:8083')
 
-	beforeAll(async () => {
-		await new Promise((resolve) => {
-			app.listen(8083, () => {
-				resolve(null)
-			})
-		})
-	})
+    beforeAll(async () => {
+        await new Promise((resolve) => {
+            app.listen(8083, () => {
+                resolve(null)
+            })
+        })
+    })
 
-	afterAll(() => {
-		app.stop()
-	})
+    afterAll(() => {
+        app.stop()
+    })
 
-	it('redirect should set location header', async () => {
-		const { headers, status } = await treatyApp.redirect.get({
-			fetch: {
-				redirect: 'manual'
-			}
-		})
-		expect(status).toEqual(302)
-		expect(new Headers(headers).get('location')).toEqual(
-			'http://localhost:8083/true'
-		)
-	})
+    it('redirect should set location header', async () => {
+        const { headers, status } = await treatyApp.redirect.get({
+            fetch: {
+                redirect: 'manual'
+            }
+        })
+        expect(status).toEqual(302)
+        expect(new Headers(headers).get('location')).toEqual(
+            'http://localhost:8083/true'
+        )
+    })
 
-	it('redirect should set location header with post', async () => {
-		const { headers, status } = await treatyApp.redirect.post(
-			{
-				username: 'a'
-			},
-			{
-				fetch: {
-					redirect: 'manual'
-				}
-			}
-		)
-		expect(status).toEqual(302)
-		expect(new Headers(headers).get('location')).toEqual(
-			'http://localhost:8083/true'
-		)
-	})
+    it('redirect should set location header with post', async () => {
+        const { headers, status } = await treatyApp.redirect.post(
+            {
+                username: 'a'
+            },
+            {
+                fetch: {
+                    redirect: 'manual'
+                }
+            }
+        )
+        expect(status).toEqual(302)
+        expect(new Headers(headers).get('location')).toEqual(
+            'http://localhost:8083/true'
+        )
+    })
 
-	it('get formdata', async () => {
-		const { data } = await treatyApp.formdata.get()
+    it('get formdata', async () => {
+        const { data } = await treatyApp.formdata.get()
 
-		expect(data!.image.size).toBeGreaterThan(0)
-	})
+        expect(data!.image.size).toBeGreaterThan(0)
+    })
 
-	it("doesn't encode if it doesn't need to", async () => {
-		const mockedFetch: any = mock((url: string) => {
-			return new Response(url)
-		})
+    it("doesn't encode if it doesn't need to", async () => {
+        const mockedFetch: any = mock((url: string) => {
+            return new Response(url)
+        })
 
-		const client = treaty<typeof app>('localhost', { fetcher: mockedFetch })
+        const client = treaty<typeof app>('localhost', { fetcher: mockedFetch })
 
-		const { data } = await client.index.get({
-			query: {
-				hello: 'world'
-			}
-		})
+        const { data } = await client.index.get({
+            query: {
+                hello: 'world'
+            }
+        })
 
-		expect(data).toEqual('http://localhost/?hello=world' as any)
-	})
+        expect(data).toEqual('http://localhost/?hello=world' as any)
+    })
 
-	it('encodes query parameters if it needs to', async () => {
-		const mockedFetch: any = mock((url: string) => {
-			return new Response(url)
-		})
+    it('encodes query parameters if it needs to', async () => {
+        const mockedFetch: any = mock((url: string) => {
+            return new Response(url)
+        })
 
-		const client = treaty<typeof app>('localhost', { fetcher: mockedFetch })
+        const client = treaty<typeof app>('localhost', { fetcher: mockedFetch })
 
-		const { data } = await client.index.get({
-			query: {
-				['1/2']: '1/2'
-			}
-		})
+        const { data } = await client.index.get({
+            query: {
+                ['1/2']: '1/2'
+            }
+        })
 
-		expect(data).toEqual('http://localhost/?1%2F2=1%2F2' as any)
-	})
+        expect(data).toEqual('http://localhost/?1%2F2=1%2F2' as any)
+    })
 
-	it('accepts and serializes several values for the same query parameter', async () => {
-		const mockedFetch: any = mock((url: string) => {
-			return new Response(url)
-		})
+    it('accepts and serializes several values for the same query parameter', async () => {
+        const mockedFetch: any = mock((url: string) => {
+            return new Response(url)
+        })
 
-		const client = treaty<typeof app>('localhost', { fetcher: mockedFetch })
+        const client = treaty<typeof app>('localhost', { fetcher: mockedFetch })
 
-		const { data } = await client.index.get({
-			query: {
-				['1/2']: ['1/2', '1 2']
-			}
-		})
+        const { data } = await client.index.get({
+            query: {
+                ['1/2']: ['1/2', '1 2']
+            }
+        })
 
-		expect(data).toEqual('http://localhost/?1%2F2=1%2F2&1%2F2=1%202' as any)
-	})
+        expect(data).toEqual('http://localhost/?1%2F2=1%2F2&1%2F2=1%202' as any)
+    })
 
-	it('Receives the proper objects back from the other end of the websocket', async (done) => {
-		app.listen(8080, async () => {
-			const client = treaty<typeof app>('http://localhost:8080')
+    it('Receives the proper objects back from the other end of the websocket', async (done) => {
+        app.listen(8080, async () => {
+            const client = treaty<typeof app>('http://localhost:8080')
 
-			const dataOutOfSocket = await new Promise<any[]>((res) => {
-				const data: any = []
-				// Wait until we've gotten all the data
-				const socket =
-					client['json-serialization-deserialization'].subscribe()
-				socket.subscribe(({ data: dataItem }) => {
-					data.push(dataItem)
-					// Only continue when we got all the messages
-					if (data.length === websocketPayloads.length) {
-						res(data)
-					}
-				})
-			})
+            const dataOutOfSocket = await new Promise<any[]>((res) => {
+                const data: any = []
+                // Wait until we've gotten all the data
+                const socket =
+                    client['json-serialization-deserialization'].subscribe()
+                socket.subscribe(({ data: dataItem }) => {
+                    data.push(dataItem)
+                    // Only continue when we got all the messages
+                    if (data.length === websocketPayloads.length) {
+                        res(data)
+                    }
+                })
+            })
 
-			// expect that everything that came out of the socket
-			// got deserialized into the same thing that we inteded to send
-			for (let i = 0; i < websocketPayloads.length; i++) {
-				expect(dataOutOfSocket[i]).toEqual(websocketPayloads[i])
-			}
+            // expect that everything that came out of the socket
+            // got deserialized into the same thing that we inteded to send
+            for (let i = 0; i < websocketPayloads.length; i++) {
+                expect(dataOutOfSocket[i]).toEqual(websocketPayloads[i])
+            }
 
-			done()
-		})
-	})
+            done()
+        })
+    })
 
-	it('return concise response', async () => {
+    it('return concise response', async () => {
         const r = await throwingClient.index.get()
 
         expect(r).toBe('a')

--- a/test/types/treaty2.ts
+++ b/test/types/treaty2.ts
@@ -3,1039 +3,1039 @@ import { treaty } from '../../src'
 import { expectTypeOf } from 'expect-type'
 
 const plugin = new Elysia({ prefix: '/level' })
-	.get('/', '2')
-	.get('/level', '2')
-	.get('/:id', ({ params: { id } }) => id)
-	.get('/:id/ok', ({ params: { id } }) => id)
+    .get('/', '2')
+    .get('/level', '2')
+    .get('/:id', ({ params: { id } }) => id)
+    .get('/:id/ok', ({ params: { id } }) => id)
 
 const app = new Elysia()
-	.get('/', 'a')
-	.post('/', 'a')
-	.get('/number', () => 1 as const)
-	.get('/true', () => true)
-	.post('/array', ({ body }) => body, {
-		body: t.Array(t.String())
-	})
-	.post('/mirror', ({ body }) => body)
-	.post('/body', ({ body }) => body, {
-		body: t.String()
-	})
-	.post('/deep/nested/mirror', ({ body }) => body, {
-		body: t.Object({
-			username: t.String(),
-			password: t.String()
-		})
-	})
-	.get('/query', ({ query }) => query, {
-		query: t.Object({
-			username: t.String()
-		})
-	})
-	.get('/queries', ({ query }) => query, {
-		query: t.Object({
-			username: t.String(),
-			alias: t.Literal('Kristen')
-		})
-	})
-	.post('/queries', ({ query }) => query, {
-		query: t.Object({
-			username: t.String(),
-			alias: t.Literal('Kristen')
-		})
-	})
-	.head('/queries', ({ query }) => query, {
-		query: t.Object({
-			username: t.String(),
-			alias: t.Literal('Kristen')
-		})
-	})
-	.group('/nested', (app) => app.guard((app) => app.get('/data', () => 'hi')))
-	.get('/error', ({ error }) => error("I'm a teapot", 'Kirifuji Nagisa'), {
-		response: {
-			200: t.Void(),
-			418: t.Literal('Kirifuji Nagisa'),
-			420: t.Literal('Snoop Dogg')
-		}
-	})
-	.get(
-		'/headers',
-		({ headers: { username, alias } }) => ({ username, alias }),
-		{
-			headers: t.Object({
-				username: t.String(),
-				alias: t.Literal('Kristen')
-			})
-		}
-	)
-	.post(
-		'/headers',
-		({ headers: { username, alias } }) => ({ username, alias }),
-		{
-			headers: t.Object({
-				username: t.String(),
-				alias: t.Literal('Kristen')
-			})
-		}
-	)
-	.get(
-		'/queries-headers',
-		({ headers: { username, alias } }) => ({ username, alias }),
-		{
-			query: t.Object({
-				username: t.String(),
-				alias: t.Literal('Kristen')
-			}),
-			headers: t.Object({
-				username: t.String(),
-				alias: t.Literal('Kristen')
-			})
-		}
-	)
-	.post(
-		'/queries-headers',
-		({ headers: { username, alias } }) => ({ username, alias }),
-		{
-			query: t.Object({
-				username: t.String(),
-				alias: t.Literal('Kristen')
-			}),
-			headers: t.Object({
-				username: t.String(),
-				alias: t.Literal('Kristen')
-			})
-		}
-	)
-	.post(
-		'/body-queries-headers',
-		({ headers: { username, alias } }) => ({ username, alias }),
-		{
-			body: t.Object({
-				username: t.String(),
-				alias: t.Literal('Kristen')
-			}),
-			query: t.Object({
-				username: t.String(),
-				alias: t.Literal('Kristen')
-			}),
-			headers: t.Object({
-				username: t.String(),
-				alias: t.Literal('Kristen')
-			})
-		}
-	)
-	.get('/async', async ({ error }) => {
-		if (Math.random() > 0.5) return error(418, 'Nagisa')
-		if (Math.random() > 0.5) return error(401, 'Himari')
+    .get('/', 'a')
+    .post('/', 'a')
+    .get('/number', () => 1 as const)
+    .get('/true', () => true)
+    .post('/array', ({ body }) => body, {
+        body: t.Array(t.String())
+    })
+    .post('/mirror', ({ body }) => body)
+    .post('/body', ({ body }) => body, {
+        body: t.String()
+    })
+    .post('/deep/nested/mirror', ({ body }) => body, {
+        body: t.Object({
+            username: t.String(),
+            password: t.String()
+        })
+    })
+    .get('/query', ({ query }) => query, {
+        query: t.Object({
+            username: t.String()
+        })
+    })
+    .get('/queries', ({ query }) => query, {
+        query: t.Object({
+            username: t.String(),
+            alias: t.Literal('Kristen')
+        })
+    })
+    .post('/queries', ({ query }) => query, {
+        query: t.Object({
+            username: t.String(),
+            alias: t.Literal('Kristen')
+        })
+    })
+    .head('/queries', ({ query }) => query, {
+        query: t.Object({
+            username: t.String(),
+            alias: t.Literal('Kristen')
+        })
+    })
+    .group('/nested', (app) => app.guard((app) => app.get('/data', () => 'hi')))
+    .get('/error', ({ error }) => error("I'm a teapot", 'Kirifuji Nagisa'), {
+        response: {
+            200: t.Void(),
+            418: t.Literal('Kirifuji Nagisa'),
+            420: t.Literal('Snoop Dogg')
+        }
+    })
+    .get(
+        '/headers',
+        ({ headers: { username, alias } }) => ({ username, alias }),
+        {
+            headers: t.Object({
+                username: t.String(),
+                alias: t.Literal('Kristen')
+            })
+        }
+    )
+    .post(
+        '/headers',
+        ({ headers: { username, alias } }) => ({ username, alias }),
+        {
+            headers: t.Object({
+                username: t.String(),
+                alias: t.Literal('Kristen')
+            })
+        }
+    )
+    .get(
+        '/queries-headers',
+        ({ headers: { username, alias } }) => ({ username, alias }),
+        {
+            query: t.Object({
+                username: t.String(),
+                alias: t.Literal('Kristen')
+            }),
+            headers: t.Object({
+                username: t.String(),
+                alias: t.Literal('Kristen')
+            })
+        }
+    )
+    .post(
+        '/queries-headers',
+        ({ headers: { username, alias } }) => ({ username, alias }),
+        {
+            query: t.Object({
+                username: t.String(),
+                alias: t.Literal('Kristen')
+            }),
+            headers: t.Object({
+                username: t.String(),
+                alias: t.Literal('Kristen')
+            })
+        }
+    )
+    .post(
+        '/body-queries-headers',
+        ({ headers: { username, alias } }) => ({ username, alias }),
+        {
+            body: t.Object({
+                username: t.String(),
+                alias: t.Literal('Kristen')
+            }),
+            query: t.Object({
+                username: t.String(),
+                alias: t.Literal('Kristen')
+            }),
+            headers: t.Object({
+                username: t.String(),
+                alias: t.Literal('Kristen')
+            })
+        }
+    )
+    .get('/async', async ({ error }) => {
+        if (Math.random() > 0.5) return error(418, 'Nagisa')
+        if (Math.random() > 0.5) return error(401, 'Himari')
 
-		return 'Hifumi'
-	})
-	.use(plugin)
+        return 'Hifumi'
+    })
+    .use(plugin)
 
 const api = treaty(app)
-const throwingApi = treaty(app, { shouldThrow: true })
+const throwingApi = treaty(app, { throw: true })
 type api = typeof api
 type throwingApi = typeof throwingApi
 
 type Result<T extends Function> = T extends (...args: any[]) => infer R
-	? Awaited<R>
-	: never
+    ? Awaited<R>
+    : never
 
 type ValidationError = {
-	data: null
-	error: {
-		status: 422
-		value: {
-			type: 'validation'
-			on: string
-			summary?: string
-			message?: string
-			found?: unknown
-			property?: string
-			expected?: string
-		}
-	}
-	response: Response
-	status: number
-	headers: FetchRequestInit['headers']
+    data: null
+    error: {
+        status: 422
+        value: {
+            type: 'validation'
+            on: string
+            summary?: string
+            message?: string
+            found?: unknown
+            property?: string
+            expected?: string
+        }
+    }
+    response: Response
+    status: number
+    headers: FetchRequestInit['headers']
 }
 
 // ? Get should have 1 parameter and is optional when no parameter is defined
 {
-	type Route = api['index']['get']
+    type Route = api['index']['get']
 
-	expectTypeOf<Route>().parameter(0).toEqualTypeOf<
-		| {
-				headers?: Record<string, unknown> | undefined
-				query?: Record<string, unknown> | undefined
-				fetch?: RequestInit | undefined
-		  }
-		| undefined
-	>()
+    expectTypeOf<Route>().parameter(0).toEqualTypeOf<
+        | {
+              headers?: Record<string, unknown> | undefined
+              query?: Record<string, unknown> | undefined
+              fetch?: RequestInit | undefined
+          }
+        | undefined
+    >()
 
-	expectTypeOf<Route>().parameter(1).toBeUndefined()
+    expectTypeOf<Route>().parameter(1).toBeUndefined()
 
-	type Res = Result<Route>
+    type Res = Result<Route>
 
-	expectTypeOf<Res>().toEqualTypeOf<
-		| {
-				data: 'a'
-				error: null
-				response: Response
-				status: number
-				headers: HeadersInit | undefined
-		  }
-		| {
-				data: null
-				error: {
-					status: unknown
-					value: unknown
-				}
-				response: Response
-				status: number
-				headers: HeadersInit | undefined
-		  }
-	>()
+    expectTypeOf<Res>().toEqualTypeOf<
+        | {
+              data: 'a'
+              error: null
+              response: Response
+              status: number
+              headers: HeadersInit | undefined
+          }
+        | {
+              data: null
+              error: {
+                  status: unknown
+                  value: unknown
+              }
+              response: Response
+              status: number
+              headers: HeadersInit | undefined
+          }
+    >()
 }
 
 // ? Non-get should have 2 parameter and is optional when no parameter is defined
 {
-	type Route = api['index']['post']
+    type Route = api['index']['post']
 
-	expectTypeOf<Route>().parameter(0).toBeUnknown()
+    expectTypeOf<Route>().parameter(0).toBeUnknown()
 
-	expectTypeOf<Route>().parameter(1).toEqualTypeOf<
-		| {
-				headers?: Record<string, unknown> | undefined
-				query?: Record<string, unknown> | undefined
-				fetch?: RequestInit | undefined
-		  }
-		| undefined
-	>()
+    expectTypeOf<Route>().parameter(1).toEqualTypeOf<
+        | {
+              headers?: Record<string, unknown> | undefined
+              query?: Record<string, unknown> | undefined
+              fetch?: RequestInit | undefined
+          }
+        | undefined
+    >()
 
-	type Res = Result<Route>
+    type Res = Result<Route>
 
-	expectTypeOf<Res>().toEqualTypeOf<
-		| {
-				data: 'a'
-				error: null
-				response: Response
-				status: number
-				headers: HeadersInit | undefined
-		  }
-		| {
-				data: null
-				error: {
-					status: unknown
-					value: unknown
-				}
-				response: Response
-				status: number
-				headers: HeadersInit | undefined
-		  }
-	>()
+    expectTypeOf<Res>().toEqualTypeOf<
+        | {
+              data: 'a'
+              error: null
+              response: Response
+              status: number
+              headers: HeadersInit | undefined
+          }
+        | {
+              data: null
+              error: {
+                  status: unknown
+                  value: unknown
+              }
+              response: Response
+              status: number
+              headers: HeadersInit | undefined
+          }
+    >()
 }
 
 // ? Should return literal
 {
-	type Route = api['number']['get']
+    type Route = api['number']['get']
 
-	expectTypeOf<Route>().parameter(0).toEqualTypeOf<
-		| {
-				headers?: Record<string, unknown> | undefined
-				query?: Record<string, unknown> | undefined
-				fetch?: RequestInit | undefined
-		  }
-		| undefined
-	>()
+    expectTypeOf<Route>().parameter(0).toEqualTypeOf<
+        | {
+              headers?: Record<string, unknown> | undefined
+              query?: Record<string, unknown> | undefined
+              fetch?: RequestInit | undefined
+          }
+        | undefined
+    >()
 
-	expectTypeOf<Route>().parameter(1).toBeUndefined()
+    expectTypeOf<Route>().parameter(1).toBeUndefined()
 
-	type Res = Result<Route>
+    type Res = Result<Route>
 
-	expectTypeOf<Res>().toEqualTypeOf<
-		| {
-				data: 1
-				error: null
-				response: Response
-				status: number
-				headers: HeadersInit | undefined
-		  }
-		| {
-				data: null
-				error: {
-					status: unknown
-					value: unknown
-				}
-				response: Response
-				status: number
-				headers: HeadersInit | undefined
-		  }
-	>()
+    expectTypeOf<Res>().toEqualTypeOf<
+        | {
+              data: 1
+              error: null
+              response: Response
+              status: number
+              headers: HeadersInit | undefined
+          }
+        | {
+              data: null
+              error: {
+                  status: unknown
+                  value: unknown
+              }
+              response: Response
+              status: number
+              headers: HeadersInit | undefined
+          }
+    >()
 }
 
 // ? Should return boolean
 {
-	type Route = api['true']['get']
+    type Route = api['true']['get']
 
-	expectTypeOf<Route>().parameter(0).toEqualTypeOf<
-		| {
-				headers?: Record<string, unknown> | undefined
-				query?: Record<string, unknown> | undefined
-				fetch?: RequestInit | undefined
-		  }
-		| undefined
-	>()
+    expectTypeOf<Route>().parameter(0).toEqualTypeOf<
+        | {
+              headers?: Record<string, unknown> | undefined
+              query?: Record<string, unknown> | undefined
+              fetch?: RequestInit | undefined
+          }
+        | undefined
+    >()
 
-	expectTypeOf<Route>().parameter(1).toBeUndefined()
+    expectTypeOf<Route>().parameter(1).toBeUndefined()
 
-	type Res = Result<Route>
+    type Res = Result<Route>
 
-	expectTypeOf<Res>().toEqualTypeOf<
-		| {
-				data: boolean
-				error: null
-				response: Response
-				status: number
-				headers: HeadersInit | undefined
-		  }
-		| {
-				data: null
-				error: {
-					status: unknown
-					value: unknown
-				}
-				response: Response
-				status: number
-				headers: HeadersInit | undefined
-		  }
-	>()
+    expectTypeOf<Res>().toEqualTypeOf<
+        | {
+              data: boolean
+              error: null
+              response: Response
+              status: number
+              headers: HeadersInit | undefined
+          }
+        | {
+              data: null
+              error: {
+                  status: unknown
+                  value: unknown
+              }
+              response: Response
+              status: number
+              headers: HeadersInit | undefined
+          }
+    >()
 }
 
 // ? Should return array of string
 {
-	type Route = api['array']['post']
+    type Route = api['array']['post']
 
-	expectTypeOf<Route>().parameter(0).toEqualTypeOf<string[]>()
+    expectTypeOf<Route>().parameter(0).toEqualTypeOf<string[]>()
 
-	expectTypeOf<Route>().parameter(1).toEqualTypeOf<
-		| {
-				headers?: Record<string, unknown> | undefined
-				query?: Record<string, unknown> | undefined
-				fetch?: RequestInit | undefined
-		  }
-		| undefined
-	>()
+    expectTypeOf<Route>().parameter(1).toEqualTypeOf<
+        | {
+              headers?: Record<string, unknown> | undefined
+              query?: Record<string, unknown> | undefined
+              fetch?: RequestInit | undefined
+          }
+        | undefined
+    >()
 
-	type Res = Result<Route>
+    type Res = Result<Route>
 
-	expectTypeOf<Res>().toEqualTypeOf<
-		| {
-				data: string[]
-				error: null
-				response: Response
-				status: number
-				headers: FetchRequestInit['headers']
-		  }
-		| ValidationError
-	>()
+    expectTypeOf<Res>().toEqualTypeOf<
+        | {
+              data: string[]
+              error: null
+              response: Response
+              status: number
+              headers: FetchRequestInit['headers']
+          }
+        | ValidationError
+    >()
 }
 
 // ? Should return body
 {
-	type Route = api['mirror']['post']
+    type Route = api['mirror']['post']
 
-	expectTypeOf<Route>().parameter(0).toBeUnknown()
+    expectTypeOf<Route>().parameter(0).toBeUnknown()
 
-	expectTypeOf<Route>().parameter(1).toEqualTypeOf<
-		| {
-				headers?: Record<string, unknown> | undefined
-				query?: Record<string, unknown> | undefined
-				fetch?: RequestInit | undefined
-		  }
-		| undefined
-	>()
-	type Res = Result<Route>
+    expectTypeOf<Route>().parameter(1).toEqualTypeOf<
+        | {
+              headers?: Record<string, unknown> | undefined
+              query?: Record<string, unknown> | undefined
+              fetch?: RequestInit | undefined
+          }
+        | undefined
+    >()
+    type Res = Result<Route>
 
-	expectTypeOf<Res>().toEqualTypeOf<
-		| {
-				data: unknown
-				error: null
-				response: Response
-				status: number
-				headers: HeadersInit | undefined
-		  }
-		| {
-				data: null
-				error: {
-					status: unknown
-					value: unknown
-				}
-				response: Response
-				status: number
-				headers: HeadersInit | undefined
-		  }
-	>()
+    expectTypeOf<Res>().toEqualTypeOf<
+        | {
+              data: unknown
+              error: null
+              response: Response
+              status: number
+              headers: HeadersInit | undefined
+          }
+        | {
+              data: null
+              error: {
+                  status: unknown
+                  value: unknown
+              }
+              response: Response
+              status: number
+              headers: HeadersInit | undefined
+          }
+    >()
 }
 
 // ? Should return body
 {
-	type Route = api['body']['post']
+    type Route = api['body']['post']
 
-	expectTypeOf<Route>().parameter(0).toEqualTypeOf<string>()
+    expectTypeOf<Route>().parameter(0).toEqualTypeOf<string>()
 
-	expectTypeOf<Route>().parameter(1).toEqualTypeOf<
-		| {
-				headers?: Record<string, unknown> | undefined
-				query?: Record<string, unknown> | undefined
-				fetch?: RequestInit | undefined
-		  }
-		| undefined
-	>()
-	type Res = Result<Route>
+    expectTypeOf<Route>().parameter(1).toEqualTypeOf<
+        | {
+              headers?: Record<string, unknown> | undefined
+              query?: Record<string, unknown> | undefined
+              fetch?: RequestInit | undefined
+          }
+        | undefined
+    >()
+    type Res = Result<Route>
 
-	expectTypeOf<Res>().toEqualTypeOf<
-		| {
-				data: string
-				error: null
-				response: Response
-				status: number
-				headers: FetchRequestInit['headers']
-		  }
-		| {
-				data: null
-				error: {
-					status: 422
-					value: {
-						type: 'validation'
-						on: string
-						summary?: string
-						message?: string
-						found?: unknown
-						property?: string
-						expected?: string
-					}
-				}
-				response: Response
-				status: number
-				headers: FetchRequestInit['headers']
-		  }
-	>()
+    expectTypeOf<Res>().toEqualTypeOf<
+        | {
+              data: string
+              error: null
+              response: Response
+              status: number
+              headers: FetchRequestInit['headers']
+          }
+        | {
+              data: null
+              error: {
+                  status: 422
+                  value: {
+                      type: 'validation'
+                      on: string
+                      summary?: string
+                      message?: string
+                      found?: unknown
+                      property?: string
+                      expected?: string
+                  }
+              }
+              response: Response
+              status: number
+              headers: FetchRequestInit['headers']
+          }
+    >()
 }
 
 // ? Should return body
 {
-	type Route = api['deep']['nested']['mirror']['post']
+    type Route = api['deep']['nested']['mirror']['post']
 
-	expectTypeOf<Route>().parameter(0).toEqualTypeOf<{
-		username: string
-		password: string
-	}>()
+    expectTypeOf<Route>().parameter(0).toEqualTypeOf<{
+        username: string
+        password: string
+    }>()
 
-	expectTypeOf<Route>().parameter(1).toEqualTypeOf<
-		| {
-				headers?: Record<string, unknown> | undefined
-				query?: Record<string, unknown> | undefined
-				fetch?: RequestInit | undefined
-		  }
-		| undefined
-	>()
+    expectTypeOf<Route>().parameter(1).toEqualTypeOf<
+        | {
+              headers?: Record<string, unknown> | undefined
+              query?: Record<string, unknown> | undefined
+              fetch?: RequestInit | undefined
+          }
+        | undefined
+    >()
 
-	type Res = Result<Route>
+    type Res = Result<Route>
 
-	expectTypeOf<Res>().toEqualTypeOf<
-		| {
-				data: {
-					username: string
-					password: string
-				}
-				error: null
-				response: Response
-				status: number
-				headers: FetchRequestInit['headers']
-		  }
-		| ValidationError
-	>()
+    expectTypeOf<Res>().toEqualTypeOf<
+        | {
+              data: {
+                  username: string
+                  password: string
+              }
+              error: null
+              response: Response
+              status: number
+              headers: FetchRequestInit['headers']
+          }
+        | ValidationError
+    >()
 }
 
 // ? Get should have 1 parameter and is required when query is defined
 {
-	type Route = api['query']['get']
+    type Route = api['query']['get']
 
-	expectTypeOf<Route>().parameter(0).toEqualTypeOf<{
-		headers?: Record<string, unknown> | undefined
-		query: {
-			username: string
-		}
-		fetch?: RequestInit | undefined
-	}>()
+    expectTypeOf<Route>().parameter(0).toEqualTypeOf<{
+        headers?: Record<string, unknown> | undefined
+        query: {
+            username: string
+        }
+        fetch?: RequestInit | undefined
+    }>()
 
-	expectTypeOf<Route>().parameter(1).toBeUndefined()
+    expectTypeOf<Route>().parameter(1).toBeUndefined()
 
-	type Res = Result<Route>
+    type Res = Result<Route>
 
-	expectTypeOf<Res>().toEqualTypeOf<
-		| {
-				data: {
-					username: string
-				}
-				error: null
-				response: Response
-				status: number
-				headers: HeadersInit | undefined
-		  }
-		| ValidationError
-	>()
+    expectTypeOf<Res>().toEqualTypeOf<
+        | {
+              data: {
+                  username: string
+              }
+              error: null
+              response: Response
+              status: number
+              headers: HeadersInit | undefined
+          }
+        | ValidationError
+    >()
 }
 
 // ? Get should have 1 parameter and is required when query is defined
 {
-	type Route = api['queries']['get']
+    type Route = api['queries']['get']
 
-	expectTypeOf<Route>().parameter(0).toEqualTypeOf<{
-		headers?: Record<string, unknown> | undefined
-		query: {
-			username: string
-			alias: 'Kristen'
-		}
-		fetch?: RequestInit | undefined
-	}>()
+    expectTypeOf<Route>().parameter(0).toEqualTypeOf<{
+        headers?: Record<string, unknown> | undefined
+        query: {
+            username: string
+            alias: 'Kristen'
+        }
+        fetch?: RequestInit | undefined
+    }>()
 
-	expectTypeOf<Route>().parameter(1).toBeUndefined()
+    expectTypeOf<Route>().parameter(1).toBeUndefined()
 
-	type Res = Result<Route>
+    type Res = Result<Route>
 
-	expectTypeOf<Res>().toEqualTypeOf<
-		| {
-				data: {
-					username: string
-					alias: 'Kristen'
-				}
-				error: null
-				response: Response
-				status: number
-				headers: HeadersInit | undefined
-		  }
-		| ValidationError
-	>()
+    expectTypeOf<Res>().toEqualTypeOf<
+        | {
+              data: {
+                  username: string
+                  alias: 'Kristen'
+              }
+              error: null
+              response: Response
+              status: number
+              headers: HeadersInit | undefined
+          }
+        | ValidationError
+    >()
 }
 
 // ? Post should have 2 parameter and is required when query is defined
 {
-	type Route = api['queries']['post']
+    type Route = api['queries']['post']
 
-	expectTypeOf<Route>().parameter(0).toBeUnknown()
+    expectTypeOf<Route>().parameter(0).toBeUnknown()
 
-	expectTypeOf<Route>().parameter(1).toEqualTypeOf<{
-		headers?: Record<string, unknown> | undefined
-		query: {
-			username: string
-			alias: 'Kristen'
-		}
-		fetch?: RequestInit | undefined
-	}>()
+    expectTypeOf<Route>().parameter(1).toEqualTypeOf<{
+        headers?: Record<string, unknown> | undefined
+        query: {
+            username: string
+            alias: 'Kristen'
+        }
+        fetch?: RequestInit | undefined
+    }>()
 
-	type Res = Result<Route>
+    type Res = Result<Route>
 
-	expectTypeOf<Res>().toEqualTypeOf<
-		| {
-				data: {
-					username: string
-					alias: 'Kristen'
-				}
-				error: null
-				response: Response
-				status: number
-				headers: HeadersInit | undefined
-		  }
-		| ValidationError
-	>()
+    expectTypeOf<Res>().toEqualTypeOf<
+        | {
+              data: {
+                  username: string
+                  alias: 'Kristen'
+              }
+              error: null
+              response: Response
+              status: number
+              headers: HeadersInit | undefined
+          }
+        | ValidationError
+    >()
 }
 
 // ? Head should have 1 parameter and is required when query is defined
 {
-	type Route = api['queries']['head']
+    type Route = api['queries']['head']
 
-	expectTypeOf<Route>().parameter(0).toEqualTypeOf<{
-		headers?: Record<string, unknown> | undefined
-		query: {
-			username: string
-			alias: 'Kristen'
-		}
-		fetch?: RequestInit | undefined
-	}>()
+    expectTypeOf<Route>().parameter(0).toEqualTypeOf<{
+        headers?: Record<string, unknown> | undefined
+        query: {
+            username: string
+            alias: 'Kristen'
+        }
+        fetch?: RequestInit | undefined
+    }>()
 
-	expectTypeOf<Route>().parameter(1).toBeUndefined()
+    expectTypeOf<Route>().parameter(1).toBeUndefined()
 
-	type Res = Result<Route>
+    type Res = Result<Route>
 
-	expectTypeOf<Res>().toEqualTypeOf<
-		| {
-				data: {
-					username: string
-					alias: 'Kristen'
-				}
-				error: null
-				response: Response
-				status: number
-				headers: HeadersInit | undefined
-		  }
-		| ValidationError
-	>()
+    expectTypeOf<Res>().toEqualTypeOf<
+        | {
+              data: {
+                  username: string
+                  alias: 'Kristen'
+              }
+              error: null
+              response: Response
+              status: number
+              headers: HeadersInit | undefined
+          }
+        | ValidationError
+    >()
 }
 
 // ? Should return error
 {
-	type Route = api['error']['get']
+    type Route = api['error']['get']
 
-	expectTypeOf<Route>().parameter(0).toEqualTypeOf<
-		| {
-				headers?: Record<string, unknown> | undefined
-				query?: Record<string, unknown> | undefined
-				fetch?: RequestInit | undefined
-		  }
-		| undefined
-	>()
+    expectTypeOf<Route>().parameter(0).toEqualTypeOf<
+        | {
+              headers?: Record<string, unknown> | undefined
+              query?: Record<string, unknown> | undefined
+              fetch?: RequestInit | undefined
+          }
+        | undefined
+    >()
 
-	expectTypeOf<Route>().parameter(1).toBeUndefined()
+    expectTypeOf<Route>().parameter(1).toBeUndefined()
 
-	type Res = Result<Route>
+    type Res = Result<Route>
 
-	expectTypeOf<Res>().toEqualTypeOf<
-		| {
-				data: never
-				error: null
-				response: Response
-				status: number
-				headers: HeadersInit | undefined
-		  }
-		| {
-				data: null
-				error:
-					| {
-							status: 418
-							value: 'Kirifuji Nagisa'
-					  }
-					| {
-							status: 420
-							value: 'Snoop Dogg'
-					  }
-					| {
-							status: 422
-							value: {
-								type: 'validation'
-								on: string
-								summary?: string
-								message?: string
-								found?: unknown
-								property?: string
-								expected?: string
-							}
-					  }
-				response: Response
-				status: number
-				headers: HeadersInit | undefined
-		  }
-	>()
+    expectTypeOf<Res>().toEqualTypeOf<
+        | {
+              data: never
+              error: null
+              response: Response
+              status: number
+              headers: HeadersInit | undefined
+          }
+        | {
+              data: null
+              error:
+                  | {
+                        status: 418
+                        value: 'Kirifuji Nagisa'
+                    }
+                  | {
+                        status: 420
+                        value: 'Snoop Dogg'
+                    }
+                  | {
+                        status: 422
+                        value: {
+                            type: 'validation'
+                            on: string
+                            summary?: string
+                            message?: string
+                            found?: unknown
+                            property?: string
+                            expected?: string
+                        }
+                    }
+              response: Response
+              status: number
+              headers: HeadersInit | undefined
+          }
+    >()
 }
 
 // ? Get should have 1 parameter and is required when headers is defined
 {
-	type Route = api['headers']['get']
+    type Route = api['headers']['get']
 
-	expectTypeOf<Route>().parameter(0).toEqualTypeOf<{
-		headers: {
-			username: string
-			alias: 'Kristen'
-		}
-		query?: Record<string, unknown> | undefined
-		fetch?: RequestInit | undefined
-	}>()
+    expectTypeOf<Route>().parameter(0).toEqualTypeOf<{
+        headers: {
+            username: string
+            alias: 'Kristen'
+        }
+        query?: Record<string, unknown> | undefined
+        fetch?: RequestInit | undefined
+    }>()
 
-	expectTypeOf<Route>().parameter(1).toBeUndefined()
+    expectTypeOf<Route>().parameter(1).toBeUndefined()
 
-	type Res = Result<Route>
+    type Res = Result<Route>
 
-	expectTypeOf<Res>().toEqualTypeOf<
-		| {
-				data: {
-					username: string
-					alias: 'Kristen'
-				}
-				error: null
-				response: Response
-				status: number
-				headers: HeadersInit | undefined
-		  }
-		| ValidationError
-	>()
+    expectTypeOf<Res>().toEqualTypeOf<
+        | {
+              data: {
+                  username: string
+                  alias: 'Kristen'
+              }
+              error: null
+              response: Response
+              status: number
+              headers: HeadersInit | undefined
+          }
+        | ValidationError
+    >()
 }
 
 // ? Post should have 2 parameter and is required when headers is defined
 {
-	type Route = api['headers']['post']
+    type Route = api['headers']['post']
 
-	expectTypeOf<Route>().parameter(0).toBeUnknown()
+    expectTypeOf<Route>().parameter(0).toBeUnknown()
 
-	expectTypeOf<Route>().parameter(1).toEqualTypeOf<{
-		headers: {
-			username: string
-			alias: 'Kristen'
-		}
-		query?: Record<string, unknown> | undefined
-		fetch?: RequestInit | undefined
-	}>()
+    expectTypeOf<Route>().parameter(1).toEqualTypeOf<{
+        headers: {
+            username: string
+            alias: 'Kristen'
+        }
+        query?: Record<string, unknown> | undefined
+        fetch?: RequestInit | undefined
+    }>()
 
-	type Res = Result<Route>
+    type Res = Result<Route>
 
-	expectTypeOf<Res>().toEqualTypeOf<
-		| {
-				data: {
-					username: string
-					alias: 'Kristen'
-				}
-				error: null
-				response: Response
-				status: number
-				headers: HeadersInit | undefined
-		  }
-		| ValidationError
-	>()
+    expectTypeOf<Res>().toEqualTypeOf<
+        | {
+              data: {
+                  username: string
+                  alias: 'Kristen'
+              }
+              error: null
+              response: Response
+              status: number
+              headers: HeadersInit | undefined
+          }
+        | ValidationError
+    >()
 }
 
 // ? Get should have 1 parameter and is required when queries and headers is defined
 {
-	type Route = api['queries-headers']['get']
+    type Route = api['queries-headers']['get']
 
-	expectTypeOf<Route>().parameter(0).toEqualTypeOf<{
-		headers: {
-			username: string
-			alias: 'Kristen'
-		}
-		query: {
-			username: string
-			alias: 'Kristen'
-		}
-		fetch?: RequestInit | undefined
-	}>()
+    expectTypeOf<Route>().parameter(0).toEqualTypeOf<{
+        headers: {
+            username: string
+            alias: 'Kristen'
+        }
+        query: {
+            username: string
+            alias: 'Kristen'
+        }
+        fetch?: RequestInit | undefined
+    }>()
 
-	expectTypeOf<Route>().parameter(1).toBeUndefined()
+    expectTypeOf<Route>().parameter(1).toBeUndefined()
 
-	type Res = Result<Route>
+    type Res = Result<Route>
 
-	expectTypeOf<Res>().toEqualTypeOf<
-		| {
-				data: {
-					username: string
-					alias: 'Kristen'
-				}
-				error: null
-				response: Response
-				status: number
-				headers: HeadersInit | undefined
-		  }
-		| ValidationError
-	>()
+    expectTypeOf<Res>().toEqualTypeOf<
+        | {
+              data: {
+                  username: string
+                  alias: 'Kristen'
+              }
+              error: null
+              response: Response
+              status: number
+              headers: HeadersInit | undefined
+          }
+        | ValidationError
+    >()
 }
 
 // ? Post should have 2 parameter and is required when queries and headers is defined
 {
-	type Route = api['queries-headers']['post']
+    type Route = api['queries-headers']['post']
 
-	expectTypeOf<Route>().parameter(0).toBeUnknown()
+    expectTypeOf<Route>().parameter(0).toBeUnknown()
 
-	expectTypeOf<Route>().parameter(1).toEqualTypeOf<{
-		headers: {
-			username: string
-			alias: 'Kristen'
-		}
-		query: {
-			username: string
-			alias: 'Kristen'
-		}
-		fetch?: RequestInit | undefined
-	}>()
+    expectTypeOf<Route>().parameter(1).toEqualTypeOf<{
+        headers: {
+            username: string
+            alias: 'Kristen'
+        }
+        query: {
+            username: string
+            alias: 'Kristen'
+        }
+        fetch?: RequestInit | undefined
+    }>()
 
-	type Res = Result<Route>
+    type Res = Result<Route>
 
-	expectTypeOf<Res>().toEqualTypeOf<
-		| {
-				data: {
-					username: string
-					alias: 'Kristen'
-				}
-				error: null
-				response: Response
-				status: number
-				headers: HeadersInit | undefined
-		  }
-		| ValidationError
-	>()
+    expectTypeOf<Res>().toEqualTypeOf<
+        | {
+              data: {
+                  username: string
+                  alias: 'Kristen'
+              }
+              error: null
+              response: Response
+              status: number
+              headers: HeadersInit | undefined
+          }
+        | ValidationError
+    >()
 }
 
 // ? Post should have 2 parameter and is required when queries, headers and body is defined
 {
-	type Route = api['body-queries-headers']['post']
+    type Route = api['body-queries-headers']['post']
 
-	expectTypeOf<Route>().parameter(0).toEqualTypeOf<{
-		username: string
-		alias: 'Kristen'
-	}>()
+    expectTypeOf<Route>().parameter(0).toEqualTypeOf<{
+        username: string
+        alias: 'Kristen'
+    }>()
 
-	expectTypeOf<Route>().parameter(1).toEqualTypeOf<{
-		headers: {
-			username: string
-			alias: 'Kristen'
-		}
-		query: {
-			username: string
-			alias: 'Kristen'
-		}
-		fetch?: RequestInit | undefined
-	}>()
+    expectTypeOf<Route>().parameter(1).toEqualTypeOf<{
+        headers: {
+            username: string
+            alias: 'Kristen'
+        }
+        query: {
+            username: string
+            alias: 'Kristen'
+        }
+        fetch?: RequestInit | undefined
+    }>()
 
-	type Res = Result<Route>
+    type Res = Result<Route>
 
-	expectTypeOf<Res>().toEqualTypeOf<
-		| {
-				data: {
-					username: string
-					alias: 'Kristen'
-				}
-				error: null
-				response: Response
-				status: number
-				headers: HeadersInit | undefined
-		  }
-		| ValidationError
-	>()
+    expectTypeOf<Res>().toEqualTypeOf<
+        | {
+              data: {
+                  username: string
+                  alias: 'Kristen'
+              }
+              error: null
+              response: Response
+              status: number
+              headers: HeadersInit | undefined
+          }
+        | ValidationError
+    >()
 }
 
 // ? Should handle async
 {
-	type Route = api['async']['get']
+    type Route = api['async']['get']
 
-	expectTypeOf<Route>().parameter(0).toEqualTypeOf<
-		| {
-				headers?: Record<string, unknown> | undefined
-				query?: Record<string, unknown> | undefined
-				fetch?: RequestInit | undefined
-		  }
-		| undefined
-	>()
+    expectTypeOf<Route>().parameter(0).toEqualTypeOf<
+        | {
+              headers?: Record<string, unknown> | undefined
+              query?: Record<string, unknown> | undefined
+              fetch?: RequestInit | undefined
+          }
+        | undefined
+    >()
 
-	expectTypeOf<Route>().parameter(1).toBeUndefined()
+    expectTypeOf<Route>().parameter(1).toBeUndefined()
 
-	type Res = Result<Route>
+    type Res = Result<Route>
 
-	expectTypeOf<Res>().toEqualTypeOf<
-		| {
-				data: 'Hifumi'
-				error: null
-				response: Response
-				status: number
-				headers: HeadersInit | undefined
-		  }
-		| {
-				data: null
-				error:
-					| {
-							status: 401
-							value: 'Himari'
-					  }
-					| {
-							status: 418
-							value: 'Nagisa'
-					  }
-				response: Response
-				status: number
-				headers: HeadersInit | undefined
-		  }
-	>()
+    expectTypeOf<Res>().toEqualTypeOf<
+        | {
+              data: 'Hifumi'
+              error: null
+              response: Response
+              status: number
+              headers: HeadersInit | undefined
+          }
+        | {
+              data: null
+              error:
+                  | {
+                        status: 401
+                        value: 'Himari'
+                    }
+                  | {
+                        status: 418
+                        value: 'Nagisa'
+                    }
+              response: Response
+              status: number
+              headers: HeadersInit | undefined
+          }
+    >()
 }
 
 // ? Handle param with nested path
 {
-	type SubModule = api['level']
+    type SubModule = api['level']
 
-	expectTypeOf<SubModule>().toEqualTypeOf<
-		((params: { id: string | number }) => {
-			get: (
-				options?:
-					| {
-							headers?: Record<string, unknown> | undefined
-							query?: Record<string, unknown> | undefined
-							fetch?: RequestInit | undefined
-					  }
-					| undefined
-			) => Promise<
-				| {
-						data: string
-						error: null
-						response: Response
-						status: number
-						headers: HeadersInit | undefined
-				  }
-				| ValidationError
-			>
-			ok: {
-				get: (
-					options?:
-						| {
-								headers?: Record<string, unknown> | undefined
-								query?: Record<string, unknown> | undefined
-								fetch?: RequestInit | undefined
-						  }
-						| undefined
-				) => Promise<
-					| {
-							data: string
-							error: null
-							response: Response
-							status: number
-							headers: HeadersInit | undefined
-					  }
-					| ValidationError
-				>
-			}
-		}) & {
-			index: {
-				get: (
-					options?:
-						| {
-								headers?: Record<string, unknown> | undefined
-								query?: Record<string, unknown> | undefined
-								fetch?: RequestInit | undefined
-						  }
-						| undefined
-				) => Promise<
-					| {
-							data: '2'
-							error: null
-							response: Response
-							status: number
-							headers: HeadersInit | undefined
-					  }
-					| ValidationError
-				>
-			}
-			level: {
-				get: (
-					options?:
-						| {
-								headers?: Record<string, unknown> | undefined
-								query?: Record<string, unknown> | undefined
-								fetch?: RequestInit | undefined
-						  }
-						| undefined
-				) => Promise<
-					| {
-							data: '2'
-							error: null
-							response: Response
-							status: number
-							headers: HeadersInit | undefined
-					  }
-					| ValidationError
-				>
-			}
-		}
-	>
+    expectTypeOf<SubModule>().toEqualTypeOf<
+        ((params: { id: string | number }) => {
+            get: (
+                options?:
+                    | {
+                          headers?: Record<string, unknown> | undefined
+                          query?: Record<string, unknown> | undefined
+                          fetch?: RequestInit | undefined
+                      }
+                    | undefined
+            ) => Promise<
+                | {
+                      data: string
+                      error: null
+                      response: Response
+                      status: number
+                      headers: HeadersInit | undefined
+                  }
+                | ValidationError
+            >
+            ok: {
+                get: (
+                    options?:
+                        | {
+                              headers?: Record<string, unknown> | undefined
+                              query?: Record<string, unknown> | undefined
+                              fetch?: RequestInit | undefined
+                          }
+                        | undefined
+                ) => Promise<
+                    | {
+                          data: string
+                          error: null
+                          response: Response
+                          status: number
+                          headers: HeadersInit | undefined
+                      }
+                    | ValidationError
+                >
+            }
+        }) & {
+            index: {
+                get: (
+                    options?:
+                        | {
+                              headers?: Record<string, unknown> | undefined
+                              query?: Record<string, unknown> | undefined
+                              fetch?: RequestInit | undefined
+                          }
+                        | undefined
+                ) => Promise<
+                    | {
+                          data: '2'
+                          error: null
+                          response: Response
+                          status: number
+                          headers: HeadersInit | undefined
+                      }
+                    | ValidationError
+                >
+            }
+            level: {
+                get: (
+                    options?:
+                        | {
+                              headers?: Record<string, unknown> | undefined
+                              query?: Record<string, unknown> | undefined
+                              fetch?: RequestInit | undefined
+                          }
+                        | undefined
+                ) => Promise<
+                    | {
+                          data: '2'
+                          error: null
+                          response: Response
+                          status: number
+                          headers: HeadersInit | undefined
+                      }
+                    | ValidationError
+                >
+            }
+        }
+    >
 }
 
 // ? Return AsyncGenerator on yield
 {
-	const app = new Elysia().get('', function* () {
-		yield 1
-		yield 2
-		yield 3
-	})
+    const app = new Elysia().get('', function* () {
+        yield 1
+        yield 2
+        yield 3
+    })
 
-	const { data } = await treaty(app).index.get()
+    const { data } = await treaty(app).index.get()
 
-	expectTypeOf<typeof data>().toEqualTypeOf<AsyncGenerator<
-		1 | 2 | 3,
-		void,
-		unknown
-	> | null>()
+    expectTypeOf<typeof data>().toEqualTypeOf<AsyncGenerator<
+        1 | 2 | 3,
+        void,
+        unknown
+    > | null>()
 }
 
 // ? Return actual value on generator if not yield
 {
-	const app = new Elysia().get('', function* () {
-		return 'a'
-	})
+    const app = new Elysia().get('', function* () {
+        return 'a'
+    })
 
-	const { data } = await treaty(app).index.get()
+    const { data } = await treaty(app).index.get()
 
-	expectTypeOf<typeof data>().toEqualTypeOf<string | null>()
+    expectTypeOf<typeof data>().toEqualTypeOf<string | null>()
 }
 
 // ? Return both actual value and generator if yield and return
 {
-	const app = new Elysia().get('', function* () {
-		if (Math.random() > 0.5) return 'a'
+    const app = new Elysia().get('', function* () {
+        if (Math.random() > 0.5) return 'a'
 
-		yield 1
-		yield 2
-		yield 3
-	})
+        yield 1
+        yield 2
+        yield 3
+    })
 
-	const { data } = await treaty(app).index.get()
+    const { data } = await treaty(app).index.get()
 
-	expectTypeOf<typeof data>().toEqualTypeOf<
-		| 'a'
-		| AsyncGenerator<1 | 2 | 3, 'a' | undefined, unknown>
-		| null
-		| undefined
-	>()
+    expectTypeOf<typeof data>().toEqualTypeOf<
+        | 'a'
+        | AsyncGenerator<1 | 2 | 3, 'a' | undefined, unknown>
+        | null
+        | undefined
+    >()
 }
 
 // ? Return AsyncGenerator on yield
 {
-	const app = new Elysia().get('', async function* () {
-		yield 1
-		yield 2
-		yield 3
-	})
+    const app = new Elysia().get('', async function* () {
+        yield 1
+        yield 2
+        yield 3
+    })
 
-	const { data } = await treaty(app).index.get()
+    const { data } = await treaty(app).index.get()
 
-	expectTypeOf<typeof data>().toEqualTypeOf<AsyncGenerator<
-		1 | 2 | 3,
-		void,
-		unknown
-	> | null>()
+    expectTypeOf<typeof data>().toEqualTypeOf<AsyncGenerator<
+        1 | 2 | 3,
+        void,
+        unknown
+    > | null>()
 }
 
 // ? Return actual value on generator if not yield
 {
-	const app = new Elysia().get('', async function* () {
-		return 'a'
-	})
+    const app = new Elysia().get('', async function* () {
+        return 'a'
+    })
 
-	const { data } = await treaty(app).index.get()
+    const { data } = await treaty(app).index.get()
 
-	expectTypeOf<typeof data>().toEqualTypeOf<string | null>()
+    expectTypeOf<typeof data>().toEqualTypeOf<string | null>()
 }
 
 // ? Return both actual value and generator if yield and return
 {
-	const app = new Elysia().get('', async function* () {
-		if (Math.random() > 0.5) return 'a'
+    const app = new Elysia().get('', async function* () {
+        if (Math.random() > 0.5) return 'a'
 
-		yield 1
-		yield 2
-		yield 3
-	})
+        yield 1
+        yield 2
+        yield 3
+    })
 
-	const { data } = await treaty(app).index.get()
+    const { data } = await treaty(app).index.get()
 
-	expectTypeOf<typeof data>().toEqualTypeOf<
-		| 'a'
-		| AsyncGenerator<1 | 2 | 3, 'a' | undefined, unknown>
-		| null
-		| undefined
-	>()
+    expectTypeOf<typeof data>().toEqualTypeOf<
+        | 'a'
+        | AsyncGenerator<1 | 2 | 3, 'a' | undefined, unknown>
+        | null
+        | undefined
+    >()
 }
 
 // ? Throwing api config flag should result in slimmed down result structure


### PR DESCRIPTION
This option allows for simple usage of the treaty client. It offers a `shouldThrow` in the config which makes the client throw in case of an error instead of returning the whole response object.

This reduces the boilerplate in environments where throwing is desired and simplifies the response handling:
```ts
const userResult = await backend.auth["upsert-self"].post();
if (userResult.error) {
  throw userResult.error;
}
const user = userResult.data;

// becomes
const user = await backend.auth["upsert-self"].post();
```
This way the users can decide how the client should behave per default.
Let me hear what you think! 