### PR TITLE
WebSocket: add protocols option

### DIFF
--- a/src/treaty2/index.ts
+++ b/src/treaty2/index.ts
@@ -223,7 +223,7 @@ const createProxy = (
 						path +
 						q
 
-					return new EdenWS(url)
+					return new EdenWS(url, headers['Sec-WebSocket-Protocol'])
 				}
 
 				return (async () => {

--- a/src/treaty2/ws.ts
+++ b/src/treaty2/ws.ts
@@ -5,8 +5,8 @@ import { parseMessageEvent } from '../utils/parsingUtils'
 export class EdenWS<in out Schema extends InputSchema<any> = {}> {
     ws: WebSocket
 
-    constructor(public url: string) {
-        this.ws = new WebSocket(url)
+    constructor(public url: string, protocols?: string | string[]) {
+        this.ws = new WebSocket(url, protocols)
     }
 
     send(data: Schema['body'] | Schema['body'][]) {


### PR DESCRIPTION
Would be nice to support WebSocket Sec-WebSocket-Protocol header and it can be set only via `protocols` constructor's option. Ref: https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/WebSocket#protocols

I get value from `headers['Sec-WebSocket-Protocol]` and pass it to WebSocket constructor, but a separate option for subscribe method might be better solution.

Let me know what do you think.