### PR TITLE
fix: TreatyResponse does not consider 2xx status codes other than 200 as success codes

### DIFF
--- a/src/treaty2/types.ts
+++ b/src/treaty2/types.ts
@@ -157,13 +157,24 @@ export namespace Treaty {
     //     [K in keyof T]: Awaited<T[K]>
     // }
 
+    type SingleDigit = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9
+
+    type SuccessKeys<R extends Record<number, unknown>> =
+    { [K in keyof R]:
+        K extends number
+          ? `${K}` extends `2${SingleDigit}${SingleDigit}`
+            ? K
+            : never
+          : never
+    }[keyof R];
+
     export type TreatyResponse<Res extends Record<number, unknown>> =
         | {
-              data: Res[200] extends {
+              data: Res[SuccessKeys<Res>] extends {
                   [ELYSIA_FORM_DATA]: infer Data
               }
                   ? Data
-                  : Res[200]
+                  : Res[SuccessKeys<Res>]
               error: null
               response: Response
               status: number
@@ -171,7 +182,7 @@ export namespace Treaty {
           }
         | {
               data: null
-              error: Exclude<keyof Res, 200> extends never
+              error: Exclude<keyof Res, SuccessKeys<Res>> extends never
                   ? {
                         status: unknown
                         value: unknown
@@ -185,7 +196,7 @@ export namespace Treaty {
                                 ? Data
                                 : Res[Status]
                         }
-                    }[Exclude<keyof Res, 200>]
+                    }[Exclude<keyof Res, SuccessKeys<Res>>]
               response: Response
               status: number
               headers: RequestInit['headers']


### PR DESCRIPTION
# Summary
Currently TreatyResponse only considers the status code 200 as a success. All other 2xx status codes are shown under the error object. When returning status codes other than 200, hovering on data will show the type as unknown, hovering over error shows the returned status code under the error object.

```typescript
export type TreatyResponse<Res extends Record<number, unknown>> =
        | {
              data: Res[200] extends {
                  [ELYSIA_FORM_DATA]: infer Data
              }
                  ? Data
                  : Res[200]
              error: null
              response: Response
              status: number
              headers: RequestInit['headers']
          }
        | {
              data: null
              error: Exclude<keyof Res, 200> extends never
                  ? {
                        status: unknown
                        value: unknown
                    }
                  : {
                        [Status in keyof Res]: {
                            status: Status
                            value: Res[Status] extends {
                                [ELYSIA_FORM_DATA]: infer Data
                            }
                                ? Data
                                : Res[Status]
                        }
                    }[Exclude<keyof Res, 200>]
```

This can be reproduced with the example below.

```typescript
import { treaty } from "@elysiajs/eden";
import { Elysia } from "elysia";

const app = new Elysia()
  .get("/", ({ status }) => status(201))
  .listen(3000);

type App = typeof app

const api = treaty<typeof app>("localhost:3000")

const { data, error } = await api.get()
``` 

# Solution

```typescript
type SingleDigit = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;

type SuccessKeys<R extends Record<number, unknown>> = {
  [K in keyof R]: K extends number
    ? `${K}` extends `2${SingleDigit}${SingleDigit}`
      ? K
      : never
    : never;
}[keyof R];

export type TreatyResponse<Res extends Record<number, unknown>> =
  | {
      data: Res[SuccessKeys<Res>] extends {
        [ELYSIA_FORM_DATA]: infer Data;
      }
        ? Data
        : Res[SuccessKeys<Res>];
      error: null;
      response: Response;
      status: number;
      headers: RequestInit["headers"];
    }
  | {
      data: null;
      error: Exclude<keyof Res, SuccessKeys<Res>> extends never
        ? {
            status: unknown;
            value: unknown;
          }
        : {
            [Status in keyof Res]: {
              status: Status;
              value: Res[Status] extends {
                [ELYSIA_FORM_DATA]: infer Data;
              }
                ? Data
                : Res[Status];
            };
          }[Exclude<keyof Res, SuccessKeys<Res>>];
      response: Response;
      status: number;
      headers: RequestInit["headers"];
    };
```
fixes: #199

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved response handling to support all 2xx HTTP status codes, not just 200, for success responses.

* **Refactor**
  * Generalized success and error response typing for broader compatibility with various HTTP status codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->