### PR TITLE
Correct README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ const app = edenTreaty<App>('http://localhost:8080')
 const { data: pong } = app.index.get()
 
 // data: 1895
-const { data: id } = client.id.1895.get()
+const { data: id } = app.id.1895.get()
 
 // data: { id: 1895, name: 'Skadi' }
 const { data: nendoroid } = app.mirror.post({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the README code example to use app.id.1895.get() instead of client.id.1895.get(), matching the defined app instance.
  * Improves accuracy and clarity of the quick-start example to prevent confusion.
  * No functional or API changes; this is a documentation-only update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->