### PR TITLE
fix: type hints for optional query and headers

### DIFF
--- a/src/treaty2/types.ts
+++ b/src/treaty2/types.ts
@@ -90,21 +90,17 @@ export namespace Treaty {
                     query: infer Query
                     response: infer Res extends Record<number, unknown>
                 }
-              ? ({} extends Headers
-                    ? {
-                          headers?: Record<string, unknown>
-                      }
-                    : undefined extends Headers
-                      ? { headers?: Record<string, unknown> }
+              ? (undefined extends Headers
+                    ? { headers?: Record<string, unknown> }
+                    : {} extends Headers
+                      ? { headers?: Headers & Record<string, unknown> }
                       : {
                             headers: Headers
                         }) &
-                    ({} extends Query
-                        ? {
-                              query?: Record<string, unknown>
-                          }
-                        : undefined extends Query
-                          ? { query?: Record<string, unknown> }
+                    (undefined extends Query
+                        ? { query?: Record<string, unknown> }
+                        : {} extends Query
+                          ? { query?: Query & Record<string, unknown> }
                           : { query: Query }) extends infer Param
                   ? {} extends Param
                       ? undefined extends Body


### PR DESCRIPTION
Resolves https://github.com/elysiajs/eden/issues/217

```ts
import { Elysia, t } from 'elysia'
import { treaty } from './src/treaty2'

const app = new Elysia().get('/optional', ({ query: { name } }) => name, {
    query: t.Object({
        name: t.Optional(t.String())
    }),
    headers: t.Object({
        'x-token': t.Optional(t.String())
    })
})

export type App = typeof app

const api = treaty<App>('localhost:8080')

type Query = NonNullable<Parameters<typeof api.optional.get>[0]>['query']
// type QueryParams = ({ name?: string | undefined; } & Record<string, unknown>) | undefined
type Headers = NonNullable<Parameters<typeof api.optional.get>[0]>['headers']
// ({ "x-token"?: string | undefined; } & Record<string, unknown>) | undefined

api.optional.get({
    query: {
        name: 'John',
        allowed: true // additional properties still allowed like old behavior
    },
    headers: {
        'x-token': '123',
        allowed: true // additional properties still allowed like old behavior
    }
})

api.optional.get({
    query: {
        name: 1, // type error: Type 'number' is not assignable to type 'string'.
        allowed: true
    },
    headers: {
        'x-token': 1, // type error: Type 'number' is not assignable to type 'string'.
        allowed: true
    }
})
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type inference for API request parameters to provide more consistent and flexible handling of optional versus required parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->