### PR TITLE
Fix: Correct type inference for `t.Date()` in query parameters

### DIFF
--- a/src/treaty2/types.ts
+++ b/src/treaty2/types.ts
@@ -58,6 +58,16 @@ type IsSuccessCode<S extends number> = S extends SuccessCodeRange ? true : false
 type MaybeArray<T> = T | T[]
 type MaybePromise<T> = T | Promise<T>
 
+type SerializeQueryParams<T> = T extends Record<string, any>
+  ? {
+      [K in keyof T]: T[K] extends Date
+        ? string
+        : T[K] extends Date | undefined
+          ? string | undefined
+          : T[K]
+    }
+  : T
+
 export namespace Treaty {
     interface TreatyParam {
         fetch?: RequestInit
@@ -76,7 +86,7 @@ export namespace Treaty {
             : K]: K extends 'subscribe' // ? Websocket route
             ? MaybeEmptyObject<Route['subscribe']['headers'], 'headers'> &
                   MaybeEmptyObject<
-                      Route['subscribe']['query'],
+                      SerializeQueryParams<Route['subscribe']['query']>,
                       'query'
                   > extends infer Param
                 ? (options?: Param) => EdenWS<Route['subscribe']>
@@ -89,7 +99,7 @@ export namespace Treaty {
                     response: infer Res extends Record<number, unknown>
                 }
               ? MaybeEmptyObject<Headers, 'headers'> &
-                    MaybeEmptyObject<Query, 'query'> extends infer Param
+                    MaybeEmptyObject<SerializeQueryParams<Query>, 'query'> extends infer Param
                   ? {} extends Param
                       ? undefined extends Body
                           ? K extends 'get' | 'head'

--- a/test/types/treaty2.ts
+++ b/test/types/treaty2.ts
@@ -31,6 +31,11 @@ const app = new Elysia()
             username: t.String()
         })
     })
+    .get('/date/query', ({ query }) => query, {
+        query: t.Object({
+            since: t.Date()
+        })
+    })
     .get('/queries', ({ query }) => query, {
         query: t.Object({
             username: t.String(),
@@ -489,6 +494,36 @@ type ValidationError = {
         | {
               data: {
                   username: string
+              }
+              error: null
+              response: Response
+              status: number
+              headers: HeadersInit | undefined
+          }
+        | ValidationError
+    >()
+}
+
+// ? Get should have 1 parameter with type string (for the underlying `t.Date` in the schema)
+{
+    type Route = api['date']['query']['get']
+
+    expectTypeOf<Route>().parameter(0).toEqualTypeOf<{
+        headers?: Record<string, unknown> | undefined
+        query: {
+            since: string
+        }
+        fetch?: RequestInit | undefined
+    }>()
+
+    expectTypeOf<Route>().parameter(1).toBeUndefined()
+
+    type Res = Result<Route>
+
+    expectTypeOf<Res>().toEqualTypeOf<
+        | {
+              data: {
+                  since: Date
               }
               error: null
               response: Response


### PR DESCRIPTION
## Problem

When using `t.Date()` in Elysia query schemas, Eden Treaty incorrectly infers that clients should pass `Date` objects. However, HTTP query parameters are always strings, causing a type mismatch:

```typescript
// Schema definition
.get('/metrics', ({ query }) => query, {
  query: t.Object({
    since: t.Date()
  })
})

// Current (incorrect) - TypeScript error
api.metrics.get({ query: { since: '2023-01-02T00:00:00Z' } })
//                                   ^^^^^^^^^^^^^^^^^^^^
// Error: Type 'string' is not assignable to type 'Date'

// TypeScript wants this (but doesn't work at runtime)
api.metrics.get({ query: { since: new Date('2023-01-02') } })
```

## Solution

- Added `SerializeQueryParams<T>` type helper in `src/treaty2/types.ts`
- Applied transformation to regular routes (line 100)
- Applied transformation to WebSocket subscribe routes (line 87)
- Added type-level test in `test/types/treaty2.ts`

**Client-side (Eden)**: `query: { since: string }`
**Server-side (Elysia)**: `query: { since: Date }`

## Possibly Related Issues

- #128 - Runtime Date handling in query params (Eden)
- #104 - Date types in responses (Eden)
- elysiajs/elysia#912 - Date & string union type issue in responses (still open)

This PR addresses the **type-level** issue, while previous fixes targeted runtime serialization.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved type handling for date-based query parameters, ensuring proper serialization in API requests.
  * Expanded API parameter support with better type safety for date inputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->