### PR TITLE
fix: properly await async headers functions in treaty

### DIFF
--- a/src/treaty2/types.ts
+++ b/src/treaty2/types.ts
@@ -180,7 +180,7 @@ export namespace Treaty {
             | ((
                   path: string,
                   options: RequestInit
-              ) => RequestInit['headers'] | void)
+              ) => MaybePromise<RequestInit['headers'] | void>)
         >
         onRequest?: MaybeArray<
             (

--- a/test/treaty2.test.ts
+++ b/test/treaty2.test.ts
@@ -572,6 +572,37 @@ describe('Treaty2', () => {
         })
     })
 
+    it('accept async headers configuration', async () => {
+        const client = treaty(app, {
+            async headers(path) {
+                // Simulate async operation (e.g., fetching token)
+                await new Promise((r) => setTimeout(r, 10))
+                if (path === '/headers-custom')
+                    return {
+                        'x-custom': 'custom'
+                    }
+            },
+            async onResponse(response) {
+                return { intercepted: true, data: await response.json() }
+            }
+        })
+
+        const headers = { username: 'a', alias: 'Kristen' } as const
+
+        const { data } = await client['headers-custom'].get({
+            headers
+        })
+
+        expect(data).toEqual({
+            // @ts-expect-error
+            intercepted: true,
+            data: {
+                ...headers,
+                'x-custom': 'custom'
+            }
+        })
+    })
+
     it('accept headers configuration array', async () => {
         const client = treaty(app, {
             headers: [


### PR DESCRIPTION
## Summary
- Fix bug where async `headers` config functions were not being awaited
- The Promise object was being passed through instead of the resolved header values
- This aligns `headers` behavior with `onRequest` which already properly awaits async functions

## Changes
- Make `processHeaders` async and await function results
- Move config header processing inside async IIFE
- Update TypeScript type to allow `MaybePromise` return from header functions
- Add test for async headers configuration

## Test plan
- [x] Added test case for async headers configuration
- [x] All existing tests pass (89 pass, 0 fail)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Headers configuration now supports asynchronous resolution, allowing headers to be dynamically determined through async operations without blocking initialization.

* **Tests**
  * Added test coverage for asynchronous header configuration scenarios with async response handlers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->