### PR TITLE
add .url() method to retrieve full route URLs

### DIFF
--- a/src/treaty2/index.ts
+++ b/src/treaty2/index.ts
@@ -204,6 +204,46 @@ const createProxy = (
 ): any =>
     new Proxy(() => {}, {
         get(_, param: string): any {
+            if (param === 'url') {
+                return (options?: { query?: Record<string, any> }) => {
+                    const methodPaths = [...paths]
+                    if (method.includes(methodPaths.at(-1) as any))
+                        methodPaths.pop()
+
+                    const path = '/' + methodPaths.join('/')
+
+                    const query = options?.query
+
+                    let q = ''
+                    if (query) {
+                        const append = (key: string, value: string) => {
+                            q +=
+                                (q ? '&' : '?') +
+                                `${encodeURIComponent(key)}=${encodeURIComponent(
+                                    value
+                                )}`
+                        }
+
+                        for (const [key, value] of Object.entries(query)) {
+                            if (Array.isArray(value)) {
+                                for (const v of value) append(key, v)
+                                continue
+                            }
+
+                            if (value === undefined || value === null) continue
+
+                            if (typeof value === 'object') {
+                                append(key, JSON.stringify(value))
+                                continue
+                            }
+                            append(key, `${value}`)
+                        }
+                    }
+
+                    return domain + path + q
+                }
+            }
+
             return createProxy(
                 domain,
                 config,

--- a/src/treaty2/types.ts
+++ b/src/treaty2/types.ts
@@ -95,86 +95,96 @@ export namespace Treaty {
             : 'Please install Elysia before using Eden'
 
     export type Sign<in out Route extends Record<any, any>> = {
-        [K in keyof Route as K extends `:${string}`
+        [K in keyof Route | 'url' as K extends `:${string}`
             ? never
-            : K]: K extends 'subscribe' // ? Websocket route
-            ? MaybeEmptyObject<Route['subscribe']['headers'], 'headers'> &
-                  MaybeEmptyObject<
-                      SerializeQueryParams<Route['subscribe']['query']>,
-                      'query'
-                  > extends infer Param
-                ? (options?: Param) => EdenWS<Route['subscribe']>
-                : never
-            : Route[K] extends {
-                    body: infer Body
-                    headers: infer Headers
-                    params: any
-                    query: infer Query
-                    response: infer Res extends Record<number, unknown>
-                }
-              ? MaybeEmptyObject<Headers, 'headers'> &
-                    MaybeEmptyObject<SerializeQueryParams<Query>, 'query'> extends infer Param
-                  ? {} extends Param
-                      ? undefined extends Body
-                          ? K extends 'get' | 'head'
-                              ? (
-                                    options?: Prettify<Param & TreatyParam>
-                                ) => Promise<
-                                    TreatyResponse<
-                                        ReplaceGeneratorWithAsyncGenerator<Res>
+            : K]: K extends 'url'
+            ? (options?: { query?: Record<string, any> }) => string
+            : K extends keyof Route
+            ? K extends 'subscribe' // ? Websocket route
+                ? (MaybeEmptyObject<Route['subscribe']['headers'], 'headers'> &
+                      MaybeEmptyObject<
+                          SerializeQueryParams<Route['subscribe']['query']>,
+                          'query'
+                      > extends infer Param
+                    ? (options?: Param) => EdenWS<Route['subscribe']>
+                    : never) & {
+                      url: (options?: {
+                          query?: SerializeQueryParams<Route['subscribe']['query']>
+                      }) => string
+                  }
+                : Route[K] extends {
+                        body: infer Body
+                        headers: infer Headers
+                        params: any
+                        query: infer Query
+                        response: infer Res extends Record<number, unknown>
+                    }
+                  ? (MaybeEmptyObject<Headers, 'headers'> &
+                        MaybeEmptyObject<SerializeQueryParams<Query>, 'query'> extends infer Param
+                      ? {} extends Param
+                          ? undefined extends Body
+                              ? K extends 'get' | 'head'
+                                  ? (
+                                        options?: Prettify<Param & TreatyParam>
+                                    ) => Promise<
+                                        TreatyResponse<
+                                            ReplaceGeneratorWithAsyncGenerator<Res>
+                                        >
                                     >
-                                >
-                              : (
-                                    body?: RelaxFileArrays<Body>,
-                                    options?: Prettify<Param & TreatyParam>
-                                ) => Promise<
-                                    TreatyResponse<
-                                        ReplaceGeneratorWithAsyncGenerator<Res>
+                                  : (
+                                        body?: RelaxFileArrays<Body>,
+                                        options?: Prettify<Param & TreatyParam>
+                                    ) => Promise<
+                                        TreatyResponse<
+                                            ReplaceGeneratorWithAsyncGenerator<Res>
+                                        >
                                     >
-                                >
+                              : K extends 'get' | 'head'
+                                ? (
+                                      options?: Prettify<Param & TreatyParam>
+                                  ) => Promise<
+                                      TreatyResponse<
+                                          ReplaceGeneratorWithAsyncGenerator<Res>
+                                      >
+                                  >
+                                : {} extends Body
+                                  ? (
+                                        body?: RelaxFileArrays<Body>,
+                                        options?: Prettify<Param & TreatyParam>
+                                    ) => Promise<
+                                        TreatyResponse<
+                                            ReplaceGeneratorWithAsyncGenerator<Res>
+                                        >
+                                    >
+                                  : (
+                                        body: RelaxFileArrays<Body>,
+                                        options?: Prettify<Param & TreatyParam>
+                                    ) => Promise<
+                                        TreatyResponse<
+                                            ReplaceGeneratorWithAsyncGenerator<Res>
+                                        >
+                                    >
                           : K extends 'get' | 'head'
                             ? (
-                                  options?: Prettify<Param & TreatyParam>
+                                  options: Prettify<Param & TreatyParam>
                               ) => Promise<
                                   TreatyResponse<
                                       ReplaceGeneratorWithAsyncGenerator<Res>
                                   >
                               >
-                            : {} extends Body
-                              ? (
-                                    body?: RelaxFileArrays<Body>,
-                                    options?: Prettify<Param & TreatyParam>
-                                ) => Promise<
-                                    TreatyResponse<
-                                        ReplaceGeneratorWithAsyncGenerator<Res>
-                                    >
-                                >
-                              : (
-                                    body: RelaxFileArrays<Body>,
-                                    options?: Prettify<Param & TreatyParam>
-                                ) => Promise<
-                                    TreatyResponse<
-                                        ReplaceGeneratorWithAsyncGenerator<Res>
-                                    >
-                                >
-                      : K extends 'get' | 'head'
-                        ? (
-                              options: Prettify<Param & TreatyParam>
-                          ) => Promise<
-                              TreatyResponse<
-                                  ReplaceGeneratorWithAsyncGenerator<Res>
+                            : (
+                                  body: RelaxFileArrays<Body>,
+                                  options: Prettify<Param & TreatyParam>
+                              ) => Promise<
+                                  TreatyResponse<
+                                      ReplaceGeneratorWithAsyncGenerator<Res>
+                                  >
                               >
-                          >
-                        : (
-                              body: RelaxFileArrays<Body>,
-                              options: Prettify<Param & TreatyParam>
-                          ) => Promise<
-                              TreatyResponse<
-                                  ReplaceGeneratorWithAsyncGenerator<Res>
-                              >
-                          >
-                  : never
-              : CreateParams<Route[K]>
+                      : never) & {
+                      url: (options?: { query?: SerializeQueryParams<Query> }) => string
+                  }
+                  : CreateParams<Route[K]>
+            : never
     }
 
     type CreateParams<Route extends Record<string, any>> =

--- a/test/treaty2.test.ts
+++ b/test/treaty2.test.ts
@@ -1222,3 +1222,36 @@ describe('Treaty2 - SSE Chunk Splitting (fast streaming edge cases)', () => {
         expect(data).toBe(1)
     })
 })
+
+describe('Treaty 2 - Using URL Method', () => {
+    const app = new Elysia()
+        .get('/ping', () => 'pong')
+        .get('/user/:id', ({ params: { id } }) => id)
+        .post('/data', ({ body }) => body, {
+            query: t.Object({
+                name: t.String()
+            })
+        })
+
+    const client = treaty(app)
+
+    it('should return base URL', () => {
+        expect(client.ping.url()).toBe('http://e.ly/ping')
+    })
+
+    it('should return URL with path parameters', () => {
+        expect(client.user({ id: 1 }).url()).toBe('http://e.ly/user/1')
+    })
+
+    it('should return URL with query parameters', () => {
+        expect(client.data.url({ query: { name: 'eden' } })).toBe('http://e.ly/data?name=eden')
+    })
+
+    it('should return URL from method proxy', () => {
+        expect(client.ping.get.url()).toBe('http://e.ly/ping')
+    })
+
+    it('should remove method name from URL when calling from method', () => {
+        expect(client.user({ id: 2 }).get.url()).toBe('http://e.ly/user/2')
+    })
+})


### PR DESCRIPTION
This PR adds a `.url()` method, allowing you to easily retrieve the full URL string for a route.

```typescript
const client = treaty(app)

// Basic usage
const url = client.ping.url()

// With chaining and query
const userUrl = client.user({ id: 1 }).profile.url(null, { 
    query: { detail: 'full' } 
})
// Result: "http://domain/user/1/profile?detail=full"
```