### PR TITLE
fix: Prevent treaty client from being treated as a Promise

### DIFF
--- a/src/treaty2/index.ts
+++ b/src/treaty2/index.ts
@@ -204,6 +204,8 @@ const createProxy = (
 ): any =>
     new Proxy(() => {}, {
         get(_, param: string): any {
+            if (param === 'then') return undefined
+
             return createProxy(
                 domain,
                 config,


### PR DESCRIPTION
When returning a treaty client from an async function and awaiting it, JavaScript's await checks if the resolved value has a `.then` property to determine if it's a Promise. The Proxy returns a new Proxy for `.then`, causing JavaScript to treat it as thenable and attempt to unwrap it infinitely.

## Reproduction 

```ts
async function getClient() {
    await someAsyncWork();
    return treaty<App>(url);
}

const client = await getClient(); // Hangs forever
```