### PR TITLE
fix: allow passing array to query parameters

### DIFF
--- a/src/treaty2/index.ts
+++ b/src/treaty2/index.ts
@@ -281,7 +281,7 @@ const createProxy = (
                         if (Array.isArray(value)) {
                             for (const v of value) append(key, v, true)
 
-							continue
+                            continue
                         }
 
                         append(key, value)

--- a/src/treaty2/index.ts
+++ b/src/treaty2/index.ts
@@ -261,7 +261,7 @@ const createProxy = (
 
                 let q = ''
                 if (query) {
-                    const append = (key: string, value: unknown) => {
+                    const append = (key: string, value: unknown, isArray = false) => {
                         // Explicitly exclude null and undefined values from url encoding
                         // to prevent parsing string "null" / string "undefined"
 						if (value === undefined || value === null) return
@@ -270,7 +270,7 @@ const createProxy = (
 
 						q +=
                             (q ? '&' : '?') +
-                            `${encodeURIComponent(key)}=${encodeURIComponent(
+                            `${encodeURIComponent(key)}${isArray ? '[]' : ''}=${encodeURIComponent(
                                 typeof value === 'object'
                                     ? JSON.stringify(value)
                                     : value + ''
@@ -279,9 +279,7 @@ const createProxy = (
 
                     for (const [key, value] of Object.entries(query)) {
                         if (Array.isArray(value)) {
-                            for (const v of value) append(key, v)
-
-                            continue
+                            for (const v of value) append(key, v, true)
                         }
 
                         append(key, value)

--- a/src/treaty2/index.ts
+++ b/src/treaty2/index.ts
@@ -280,6 +280,8 @@ const createProxy = (
                     for (const [key, value] of Object.entries(query)) {
                         if (Array.isArray(value)) {
                             for (const v of value) append(key, v, true)
+
+							continue
                         }
 
                         append(key, value)


### PR DESCRIPTION
The validation fail on server if it expect array in query string

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed query-string serialization for array values in GET/HEAD/subscribe requests so array items are encoded using bracketed keys (e.g., key[]). This ensures multi-value query parameters are formatted consistently and prevents malformed or ambiguous query strings when sending array data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->