### PR TITLE
fix #258: detect text streams without Transfer-Encoding (HTTP/2)

### DIFF
--- a/src/treaty2/index.ts
+++ b/src/treaty2/index.ts
@@ -635,8 +635,6 @@ const createProxy = (
 								response.headers
 									.get('content-type')
 									?.startsWith('text/') &&
-								response.headers.get('transfer-encoding') ===
-									'chunked' &&
 								!response.headers.has('content-length')
 							)
 								data = streamResponse(response, {

--- a/test/treaty2.test.ts
+++ b/test/treaty2.test.ts
@@ -1143,6 +1143,67 @@ function createChunkedSSEResponse(chunks: Array<string>): Response {
 	})
 }
 
+describe('Treaty2 - HTTP/2 streaming detection (#258)', () => {
+	function makeStreamingResponse(headers: HeadersInit): Response {
+		const encoder = new TextEncoder()
+		const stream = new ReadableStream<Uint8Array>({
+			async start(controller) {
+				controller.enqueue(encoder.encode('chunk-1'))
+				controller.enqueue(encoder.encode('chunk-2'))
+				controller.enqueue(encoder.encode('chunk-3'))
+				controller.close()
+			}
+		})
+		return new Response(stream, { headers })
+	}
+
+	it('streams text/plain when Transfer-Encoding is stripped (HTTP/2 / reverse proxy)', async () => {
+		// Reverse proxies serving HTTP/2 strip Transfer-Encoding (RFC 7540
+		// §8.1.2.2). Eden should still detect a stream when there's no
+		// Content-Length, which is the only legal way to signal a streaming
+		// body in either HTTP/1.1 (chunked, no length) or HTTP/2 (no length).
+		const client = treaty<any>('http://h2.test', {
+			fetcher: async () =>
+				makeStreamingResponse({ 'Content-Type': 'text/plain' })
+		})
+
+		const { data } = await (client as any).live.get()
+		expect(typeof data?.[Symbol.asyncIterator]).toBe('function')
+
+		const collected: unknown[] = []
+		for await (const chunk of data) collected.push(chunk)
+		expect(collected).toEqual(['chunk-1', 'chunk-2', 'chunk-3'])
+	})
+
+	it('streams text/plain with Transfer-Encoding: chunked (HTTP/1.1 direct)', async () => {
+		const client = treaty<any>('http://h1.test', {
+			fetcher: async () =>
+				makeStreamingResponse({
+					'Content-Type': 'text/plain',
+					'Transfer-Encoding': 'chunked'
+				})
+		})
+
+		const { data } = await (client as any).live.get()
+		expect(typeof data?.[Symbol.asyncIterator]).toBe('function')
+	})
+
+	it('still buffers text/plain when Content-Length is present (non-streaming)', async () => {
+		const client = treaty<any>('http://buffered.test', {
+			fetcher: async () =>
+				new Response('hello', {
+					headers: {
+						'Content-Type': 'text/plain',
+						'Content-Length': '5'
+					}
+				})
+		})
+
+		const { data } = await (client as any).hello.get()
+		expect(data).toBe('hello')
+	})
+})
+
 describe('Treaty2 - SSE Chunk Splitting (fast streaming edge cases)', () => {
 	it('handles SSE event split across chunks (data: broken mid-line)', async () => {
 		const chunks = ['event: message\nda', 'ta: hello world\n\n']


### PR DESCRIPTION
Closes #258.

`Transfer-Encoding: chunked` is forbidden in HTTP/2 (RFC 7540 §8.1.2.2) and stripped by reverse proxies on h1→h2. The detection added in #213 requires that header, so any plain-text streaming route hangs forever when served behind Traefik / nginx / Caddy / Cloudflare with HTTPS. Eden falls into `await response.text()` and a `while (true)` generator never resolves.

The chunked clause is also redundant — chunked and `Content-Length` are mutually exclusive (RFC 7230 §3.3.1), so any HTTP/1.1 chunked response already satisfies the existing `!has('content-length')` check. Dropping the chunked clause keeps h1 working and fixes h2.

### Does not regress #213

A non-streaming `text/plain` response continues to be buffered because it carries `Content-Length`. The new test `still buffers text/plain when Content-Length is present` covers this.

### Tests

Three new tests in `Treaty2 - HTTP/2 streaming detection (#258)`:

1. `text/plain` + no `Transfer-Encoding` → streams (the h2 case; fails on `main`, passes here)
2. `text/plain` + `Transfer-Encoding: chunked` → still streams (h1 regression guard)
3. `text/plain` + `Content-Length` → buffers (#213 regression guard)

Verified: with the fix all 3 pass. Without it, test 1 fails with `expected "function" Received: "undefined"` (data isn't async-iterable). Full suite stays at 5 pre-existing unrelated WebSocket failures (same on `main`).

### Possibly related

#255 / #256 fix non-SSE chunk yield semantics (chunks weren't emitting until end). Both fixes are needed for h2 plain-text streams to work end-to-end client-side, but they address different layers (parsing vs. detection) and don't conflict.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP streaming detection for text responses. The library now correctly identifies and handles text responses without explicit Content-Length headers, enabling proper streaming support in HTTP/2 and reverse proxy scenarios.

* **Tests**
  * Added comprehensive tests validating streaming detection behavior for various text response configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->