### PR TITLE
fix(eden/kiana): Accept toJSON-bearing values in request body types

### DIFF
--- a/src/fetch/types.ts
+++ b/src/fetch/types.ts
@@ -3,6 +3,7 @@ import type { EdenFetchError } from '../errors'
 import type {
 	MapError,
 	IsUnknown,
+	Serializable,
 	IsNever,
 	Prettify,
 	TreatyToPath,
@@ -61,7 +62,7 @@ export namespace EdenFetch {
 						headers: Route['headers']
 					}) &
 			(IsUnknown<Route['body']> extends false
-				? { body: Route['body'] }
+				? { body: Serializable<Route['body']> }
 				: { body?: unknown }) & {
           throwHttpError?: ThrowHttpError
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ export type {
     TreatyPlugin
 } from './treaty2'
 
+export type { Serializable } from './types'
+
 export { treaty } from './treaty2'
 export { edenTreaty } from './treaty'
 export { edenFetch } from './fetch'

--- a/src/treaty/index.ts
+++ b/src/treaty/index.ts
@@ -2,6 +2,7 @@ import type { Elysia, InputSchema } from 'elysia'
 import { EdenFetchError } from '../errors'
 import { composePath } from './utils'
 import type { EdenTreaty } from './types'
+import type { Serializable } from '../types'
 import { parseMessageEvent, parseStringifiedValue } from '../utils/parse'
 
 export type { EdenTreaty } from './types'
@@ -65,7 +66,7 @@ export class EdenWS<Schema extends InputSchema<any> = InputSchema> {
         this.url = url
     }
 
-    send(data: MaybeArray<Schema['body']>) {
+    send(data: MaybeArray<Serializable<Schema['body']>>) {
         if (Array.isArray(data)) {
             data.forEach((datum) => this.send(datum))
 

--- a/src/treaty/types.ts
+++ b/src/treaty/types.ts
@@ -1,7 +1,13 @@
 /// <reference lib="dom" />
 import { Elysia } from 'elysia'
 import type { EdenWS } from './index'
-import type { IsUnknown, IsNever, MapError, Prettify } from '../types'
+import type {
+    IsUnknown,
+    IsNever,
+    MapError,
+    Prettify,
+    Serializable
+} from '../types'
 import type { EdenFetchError } from '../errors'
 
 type Files = File | FileList
@@ -50,7 +56,7 @@ export namespace EdenTreaty {
                               getRaw?: boolean
                               $transform?: Transform
                           } & (IsUnknown<Body> extends false
-                              ? Replace<Body, Blob | Blob[], Files>
+                              ? Serializable<Replace<Body, Blob | Blob[], Files>>
                               : {}) &
                               (undefined extends Query
                                   ? {

--- a/src/treaty2/types.ts
+++ b/src/treaty2/types.ts
@@ -7,6 +7,7 @@ import type {
     MaybeEmptyObject,
     Not,
     Prettify,
+    Serializable,
     ThrowHttpError
 } from '../types'
 import type {
@@ -181,7 +182,7 @@ export namespace Treaty {
                                         >
                                     >
                                   : (
-                                        body?: RelaxFileArrays<Body>,
+                                        body?: Serializable<RelaxFileArrays<Body>>,
                                         options?: ToTreatyParam<
                                             Param,
                                             Head,
@@ -202,7 +203,7 @@ export namespace Treaty {
                                   >
                                 : {} extends Body
                                   ? (
-                                        body?: RelaxFileArrays<Body>,
+                                        body?: Serializable<RelaxFileArrays<Body>>,
                                         options?: ToTreatyParam<
                                             Param,
                                             Head,
@@ -214,7 +215,7 @@ export namespace Treaty {
                                         >
                                     >
                                   : (
-                                        body: RelaxFileArrays<Body>,
+                                        body: Serializable<RelaxFileArrays<Body>>,
                                         options?: ToTreatyParam<
                                             Param,
                                             Head,
@@ -234,7 +235,7 @@ export namespace Treaty {
                                   >
                               >
                             : (
-                                  body: RelaxFileArrays<Body>,
+                                  body: Serializable<RelaxFileArrays<Body>>,
                                   options: ToTreatyParam<
                                       Param,
                                       Head,

--- a/src/treaty2/ws.ts
+++ b/src/treaty2/ws.ts
@@ -1,5 +1,6 @@
 import type { InputSchema } from 'elysia'
 import type { Treaty } from './types'
+import type { Serializable } from '../types'
 import { parseMessageEvent } from '../utils/parse'
 
 export class EdenWS<in out Schema extends InputSchema<any> = {}> {
@@ -9,7 +10,7 @@ export class EdenWS<in out Schema extends InputSchema<any> = {}> {
         this.ws = new WebSocket(url)
     }
 
-    send(data: Schema['body'] | Schema['body'][]) {
+    send(data: Serializable<Schema['body']> | Serializable<Schema['body']>[]) {
         if (Array.isArray(data)) {
             data.forEach((datum) => this.send(datum))
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,7 +106,6 @@ export type TreatyToPath<T, Path extends string = ''> = UnionToIntersect<
 
 export type Not<T> = T extends true ? false : true
 
-/** Values the client sends as-is, never through `JSON.stringify` */
 type Opaque =
     | File
     | Blob
@@ -116,18 +115,20 @@ type Opaque =
     | ReadableStream
     | Date
 
-/** A value `JSON.stringify` replaces with its `toJSON()` result */
-type ToJSON<T> = { toJSON(key?: string): T }
+type ToJSON<T> = { toJSON(key?: string): Serialized<T> }
 
-/**
- * What a caller may pass where the wire shape must be `T`.
- *
- * The request body ends in `JSON.stringify`, which serializes a value's
- * `toJSON()` result in place of the value. So a plain `T` is accepted only
- * when it carries no `toJSON` of its own, and any object whose `toJSON()`
- * returns `T` is accepted regardless of its own shape. Applied per field;
- * `Date` satisfies `string` this way.
- */
+type Serialized<T> = T extends Opaque
+    ? T
+    : T extends (infer U)[]
+      ? Serializable<U>[]
+      : T extends object
+        ? Fields<T>
+        : T
+
+type Fields<T> = {
+    [K in keyof T]: K extends 'toJSON' ? T[K] : Serializable<T[K]>
+} & ('toJSON' extends keyof T ? {} : { toJSON?: never })
+
 export type Serializable<T> =
     IsAny<T> extends true
         ? T
@@ -138,8 +139,5 @@ export type Serializable<T> =
             : T extends (infer U)[]
               ? Serializable<U>[] | ToJSON<T>
               : T extends object
-                ? ({ [K in keyof T]: Serializable<T[K]> } & {
-                      toJSON?: never
-                  })
-                  | ToJSON<T>
+                ? Fields<T> | ToJSON<T>
                 : T | ToJSON<T>

--- a/src/types.ts
+++ b/src/types.ts
@@ -105,3 +105,41 @@ export type TreatyToPath<T, Path extends string = ''> = UnionToIntersect<
 >
 
 export type Not<T> = T extends true ? false : true
+
+/** Values the client sends as-is, never through `JSON.stringify` */
+type Opaque =
+    | File
+    | Blob
+    | FormData
+    | ArrayBuffer
+    | ArrayBufferView
+    | ReadableStream
+    | Date
+
+/** A value `JSON.stringify` replaces with its `toJSON()` result */
+type ToJSON<T> = { toJSON(key?: string): T }
+
+/**
+ * What a caller may pass where the wire shape must be `T`.
+ *
+ * The request body ends in `JSON.stringify`, which serializes a value's
+ * `toJSON()` result in place of the value. So a plain `T` is accepted only
+ * when it carries no `toJSON` of its own, and any object whose `toJSON()`
+ * returns `T` is accepted regardless of its own shape. Applied per field;
+ * `Date` satisfies `string` this way.
+ */
+export type Serializable<T> =
+    IsAny<T> extends true
+        ? T
+        : unknown extends T
+          ? T
+          : T extends Opaque
+            ? T
+            : T extends (infer U)[]
+              ? Serializable<U>[] | ToJSON<T>
+              : T extends object
+                ? ({ [K in keyof T]: Serializable<T[K]> } & {
+                      toJSON?: never
+                  })
+                  | ToJSON<T>
+                : T | ToJSON<T>

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,11 +119,13 @@ type ToJSON<T> = { toJSON(key?: string): Serialized<T> }
 
 type Serialized<T> = T extends Opaque
     ? T
-    : T extends (infer U)[]
-      ? Serializable<U>[]
+    : T extends readonly unknown[]
+      ? Elements<T>
       : T extends object
         ? Fields<T>
         : T
+
+type Elements<T> = { [K in keyof T]: Serializable<T[K]> }
 
 type Fields<T> = {
     [K in keyof T]: K extends 'toJSON' ? T[K] : Serializable<T[K]>
@@ -136,8 +138,8 @@ export type Serializable<T> =
           ? T
           : T extends Opaque
             ? T
-            : T extends (infer U)[]
-              ? Serializable<U>[] | ToJSON<T>
+            : T extends readonly unknown[]
+              ? Elements<T> | ToJSON<T>
               : T extends object
                 ? Fields<T> | ToJSON<T>
                 : T | ToJSON<T>

--- a/test/types/fetch.ts
+++ b/test/types/fetch.ts
@@ -1,0 +1,42 @@
+import { Elysia, t } from 'elysia'
+import { edenFetch } from '../../src'
+
+const app = new Elysia().post(
+    '/pay',
+    {
+        body: t.Object({
+            amount: t.Number(),
+            currency: t.String()
+        })
+    },
+    ({ body }) => body
+)
+
+const fetch = edenFetch<typeof app>('http://localhost:3000')
+
+class Money {
+    toJSON(): { amount: number; currency: string } {
+        return { amount: 1, currency: 'USD' }
+    }
+}
+
+{
+    fetch('/pay', {
+        method: 'POST',
+        body: new Money()
+    })
+}
+
+{
+    class WrongShape {
+        toJSON(): string {
+            return 'x'
+        }
+    }
+
+    fetch('/pay', {
+        method: 'POST',
+        // @ts-expect-error
+        body: new WrongShape()
+    })
+}

--- a/test/types/serializable.ts
+++ b/test/types/serializable.ts
@@ -154,3 +154,36 @@ class DoubleWrapped {
     // @ts-expect-error
     const rejected: Serializable<Body> = callable
 }
+
+class PairResult {
+    toJSON(): [number, string] {
+        return [1, 'x']
+    }
+}
+
+class LongerPairResult {
+    toJSON(): [number, string, number] {
+        return [1, 'x', 3]
+    }
+}
+
+{
+    type Pair = [number, string]
+
+    const pair: Serializable<Pair> = [1, 'x']
+    const wrapped: Serializable<Pair> = new PairResult()
+    const readonlyPair: Serializable<readonly [number, string]> = [1, 'x']
+
+    // @ts-expect-error
+    const extra: Serializable<Pair> = [1, 'x', 3]
+    // @ts-expect-error
+    const short: Serializable<Pair> = [1]
+    // @ts-expect-error
+    const swapped: Serializable<Pair> = ['x', 1]
+    // @ts-expect-error
+    const extraFromResult: Serializable<Pair> = new LongerPairResult()
+
+    expectTypeOf<Serializable<readonly number[]>>().not.toExtend<number[]>()
+    expectTypeOf(wrapped).toExtend<Serializable<Pair>>()
+    expectTypeOf(readonlyPair).toExtend<Serializable<readonly [number, string]>>()
+}

--- a/test/types/serializable.ts
+++ b/test/types/serializable.ts
@@ -114,3 +114,43 @@ class MoneyList {
 
     expectTypeOf(wholeArray).toExtend<Serializable<Body[]>>()
 }
+
+class Cents {
+    toJSON(): number {
+        return 7
+    }
+}
+
+class Order {
+    toJSON(): { price: Cents } {
+        return { price: new Cents() }
+    }
+}
+
+class DoubleWrapped {
+    toJSON(): Money {
+        return new Money(100)
+    }
+}
+
+{
+    type Body = { price: number }
+
+    const nestedResult: Serializable<Body> = new Order()
+
+    const doubleWrapped = new DoubleWrapped()
+
+    // @ts-expect-error
+    const rejected: Serializable<{ amount: number; currency: string }> = doubleWrapped
+}
+
+{
+    type Body = { toJSON: string; amount: number }
+
+    const named: Serializable<Body> = { toJSON: 'value', amount: 1 }
+
+    const callable = { toJSON: () => 'value', amount: 1 }
+
+    // @ts-expect-error
+    const rejected: Serializable<Body> = callable
+}

--- a/test/types/serializable.ts
+++ b/test/types/serializable.ts
@@ -1,0 +1,116 @@
+import { expectTypeOf } from 'expect-type'
+import type { Serializable } from '../../src/types'
+import type { Serializable as ExportedSerializable } from '../../src'
+
+class Money {
+    constructor(public cents: number) {}
+
+    toJSON(): { amount: number; currency: string } {
+        return { amount: this.cents / 100, currency: 'USD' }
+    }
+}
+
+{
+    type Body = { amount: number; currency: string }
+
+    expectTypeOf<Money>().toExtend<Serializable<Body>>()
+    expectTypeOf<Body>().toExtend<Serializable<Body>>()
+}
+
+{
+    type Body = { amount: number; currency: string }
+
+    expectTypeOf<ExportedSerializable<Body>>().toEqualTypeOf<
+        Serializable<Body>
+    >()
+}
+
+{
+    type Body = { price: { amount: number; currency: string }; at: string }
+
+    const nested: Serializable<Body> = { price: new Money(100), at: new Date() }
+}
+
+{
+    const date: Serializable<string> = new Date()
+    const text: Serializable<string> = 'hello'
+}
+
+class Wrong {
+    toJSON(): string {
+        return 'x'
+    }
+}
+
+{
+    type Body = { amount: number; currency: string }
+
+    const wrong = new Wrong()
+
+    // @ts-expect-error
+    const rejected: Serializable<Body> = wrong
+}
+
+{
+    type Body = { amount: number; currency: string }
+
+    const stray = { amount: 1, currency: 'USD', toJSON: () => 'x' }
+
+    // @ts-expect-error
+    const rejected: Serializable<Body> = stray
+}
+
+{
+    expectTypeOf<Serializable<File>>().toEqualTypeOf<File>()
+    expectTypeOf<Serializable<Blob>>().toEqualTypeOf<Blob>()
+    expectTypeOf<Serializable<Date>>().toEqualTypeOf<Date>()
+
+    const body: Serializable<{ file: File; blob: Blob; name: string }> = {
+        file: new File([], 'a'),
+        blob: new Blob([]),
+        name: 'a'
+    }
+}
+
+{
+    expectTypeOf<Serializable<unknown>>().toEqualTypeOf<unknown>()
+    expectTypeOf<Serializable<any>>().toBeAny()
+}
+
+{
+    type Body = { amount: number; currency: string }
+
+    const asNull: Serializable<Body | null | undefined> = null
+    const asUndefined: Serializable<Body | null | undefined> = undefined
+    const asMoney: Serializable<Body | null | undefined> = new Money(100)
+    const asObject: Serializable<Body | null | undefined> = {
+        amount: 1,
+        currency: 'USD'
+    }
+
+    const literalA: Serializable<'a' | 'b'> = 'a'
+    const literalB: Serializable<'a' | 'b'> = 'b'
+
+    expectTypeOf(asUndefined).toExtend<Serializable<Body | null | undefined>>()
+    expectTypeOf(asObject).toExtend<Serializable<Body | null | undefined>>()
+    expectTypeOf(literalB).toExtend<Serializable<'a' | 'b'>>()
+}
+
+class MoneyList {
+    toJSON(): { amount: number; currency: string }[] {
+        return []
+    }
+}
+
+{
+    type Body = { amount: number; currency: string }
+
+    const elementWise: Serializable<Body[]> = [
+        new Money(100),
+        { amount: 1, currency: 'USD' }
+    ]
+    const wholeArray: Serializable<Body[]> = new MoneyList()
+    const dates: Serializable<string[]> = [new Date()]
+
+    expectTypeOf(wholeArray).toExtend<Serializable<Body[]>>()
+}

--- a/test/types/treaty.ts
+++ b/test/types/treaty.ts
@@ -1,0 +1,50 @@
+import { Elysia, t } from 'elysia'
+import { edenTreaty } from '../../src'
+import type { EdenWS } from '../../src/treaty'
+
+const app = new Elysia().post(
+    '/mirror',
+    {
+        body: t.Object({
+            username: t.String(),
+            password: t.String()
+        })
+    },
+    ({ body }) => body
+)
+
+const client = edenTreaty<typeof app>('http://localhost:8082')
+
+class Credential {
+    toJSON(): { username: string; password: string } {
+        return { username: 'saltyaom', password: '12345678' }
+    }
+}
+
+{
+    client.mirror.post(new Credential())
+
+    client.mirror.post({
+        username: new Date(),
+        password: '12345678'
+    })
+}
+
+{
+    class Money {
+        toJSON(): { amount: number; currency: string } {
+            return { amount: 1, currency: 'USD' }
+        }
+    }
+
+    type Socket = EdenWS<{
+        body: { amount: number; currency: string }
+        headers: unknown
+        query: unknown
+        params: unknown
+        cookie: unknown
+        response: unknown
+    }>
+
+    const send = (socket: Socket) => socket.send(new Money())
+}

--- a/test/types/treaty2.ts
+++ b/test/types/treaty2.ts
@@ -1,7 +1,7 @@
 import { Elysia, file, form, status, t } from 'elysia'
 import { treaty } from '../../src'
 import { expectTypeOf } from 'expect-type'
-import type { ThrowHttpError } from '../../src/types'
+import type { Serializable, ThrowHttpError } from '../../src/types'
 import type { Treaty } from '../../src/treaty2/types'
 
 const plugin = new Elysia({ prefix: '/level' })
@@ -387,7 +387,7 @@ interface ValidationError {
 {
     type Route = api['array']['post']
 
-    expectTypeOf<Route>().parameter(0).toEqualTypeOf<string[]>()
+    expectTypeOf<Route>().parameter(0).toEqualTypeOf<Serializable<string[]>>()
 
     expectTypeOf<Route>().parameter(1).toEqualTypeOf<
         | {
@@ -455,7 +455,7 @@ interface ValidationError {
 {
     type Route = api['body']['post']
 
-    expectTypeOf<Route>().parameter(0).toEqualTypeOf<string>()
+    expectTypeOf<Route>().parameter(0).toEqualTypeOf<Serializable<string>>()
 
     expectTypeOf<Route>().parameter(1).toEqualTypeOf<
         | {
@@ -502,10 +502,12 @@ interface ValidationError {
 {
     type Route = api['deep']['nested']['mirror']['post']
 
-    expectTypeOf<Route>().parameter(0).toEqualTypeOf<{
-        username: string
-        password: string
-    }>()
+    expectTypeOf<Route>().parameter(0).toEqualTypeOf<
+        Serializable<{
+            username: string
+            password: string
+        }>
+    >()
 
     expectTypeOf<Route>().parameter(1).toEqualTypeOf<
         | {
@@ -881,10 +883,12 @@ interface ValidationError {
 {
     type Route = api['body-queries-headers']['post']
 
-    expectTypeOf<Route>().parameter(0).toEqualTypeOf<{
-        username: string
-        alias: 'Kristen'
-    }>()
+    expectTypeOf<Route>().parameter(0).toEqualTypeOf<
+        Serializable<{
+            username: string
+            alias: 'Kristen'
+        }>
+    >()
 
     expectTypeOf<Route>().parameter(1).toEqualTypeOf<{
         headers: {
@@ -1482,4 +1486,52 @@ interface ValidationError {
     const res = {} as Res
 
     if (!res.error) expectTypeOf(res.data).toEqualTypeOf<{ image: File }>()
+}
+
+{
+    class Credential {
+        toJSON(): { username: string; password: string } {
+            return { username: 'saltyaom', password: '12345678' }
+        }
+    }
+
+    api.deep.nested.mirror.post(new Credential())
+}
+
+{
+    api.deep.nested.mirror.post({
+        username: new Date(),
+        password: '12345678'
+    })
+}
+
+{
+    class WrongShape {
+        toJSON(): string {
+            return 'x'
+        }
+    }
+
+    const wrongShape = new WrongShape()
+
+    // @ts-expect-error
+    api.deep.nested.mirror.post(wrongShape)
+}
+
+{
+    const wsApp = new Elysia().ws('/ws', {
+        body: t.Object({
+            amount: t.Number(),
+            currency: t.String()
+        }),
+        message() {}
+    })
+
+    class Money {
+        toJSON(): { amount: number; currency: string } {
+            return { amount: 1, currency: 'USD' }
+        }
+    }
+
+    treaty(wsApp).ws.subscribe().send(new Money())
 }


### PR DESCRIPTION
# Accept `toJSON`-bearing values in request body types

> Well, well. Before you come in here with your "*ehh~? ojisan, you broke my type tests again~?*" routine, sit down. Read the whole thing. Then we'll see who's teaching whom today.

## What was wrong

Every body parameter in Eden was typed as the route's static `Body`. The runtime never sends `Body`. It sends `JSON.stringify(body)`, and `JSON.stringify` calls `toJSON()` on anything that defines it, serializing the *return value* instead of the object.

Two contracts, disagreeing:

| Layer | Contract |
| --- | --- |
| Type | argument assignable to `Body` |
| Runtime | argument's `toJSON()` result assignable to `Body` |

You'd have flagged the symptom and missed the cause. Here's the cause, laid out for you:

```ts
class Money {
    constructor(public cents: number) {}
    toJSON(): { amount: number; currency: string } {
        return { amount: this.cents / 100, currency: 'USD' }
    }
}

api.pay.post(new Money(100))
// TS2345: 'Money' is not assignable to '{ amount: number; currency: string }'
// ...bytes on the wire: {"amount":1,"currency":"USD"}. Exactly right. Compiler wrong.

api.order.post({ price: new Money(100), at: new Date() })
// TS2322: 'Date' is not assignable to 'string'
// ...Date.prototype.toJSON returns an ISO string. Every user writes .toISOString() to appease you.

api.pay.post({ amount: 1, currency: 'USD', toJSON: () => 'x' })
// compiles clean. Wire: "x". You let *that* one through for years.
```

Five distinct `tsc` errors reproduced on `kiana` before I touched anything. Query params already had a hand-rolled `Date -> string | Date` special case. The body had nothing. Someone knew and only fixed half.


Fix applied at every site where a typed value ends in `JSON.stringify`. type only, no runtime changes:

- `src/treaty2/types.ts` — the four `body` parameters in `Sign` (post/put/patch/delete)
- `src/treaty2/ws.ts` — `EdenWS.send`
- `src/fetch/types.ts` — `edenFetch` options `body`
- `src/treaty/types.ts`, `src/treaty/index.ts` — legacy v1 `Sign` body and its `EdenWS.send`

Not touched, and I'll say it before you do: `SerializeQueryParams`. It flattens arrays and drops `null`, and its display type is pinned in existing tests. Unifying it is a separate change. Response-side typing for handlers *returning* `toJSON` classes lives in Elysia's serializer, not here.

## Tests

Red first, then green, one slice at a time. I know you'd check.

- `test/types/serializable.ts` — whole-value and nested `toJSON`, `Date` for `string`, wrong-shape `toJSON` rejected, stray `toJSON` rejected, `File`/`Blob`/`Date` stay opaque, `unknown` and `any` untouched, `null`/`undefined`/literal unions distribute, arrays element-wise and whole-array
- `test/types/treaty2.ts` — class body, nested `Date`, `@ts-expect-error` wrong shape, WebSocket `send`
- `test/types/fetch.ts`, `test/types/treaty.ts` — new, same cases through those clients

Four existing `parameter(0).toEqualTypeOf<Body>()` assertions widened to `Serializable<Body>`. That's the full blast radius. I measured it before changing `Sign`, not after.

```
bun test              207 pass, 0 fail
tsc (type gate)       0 new errors
```

The one remaining gate error is `test/fetch.test.ts` missing the `file-type` module. It was there before me. Don't pin it on this PR.

## Things you *will* find, so I'm handing them to you

- **v1 `subscribe()` passes `EdenWS<Route>` instead of `EdenWS<Route['subscribe']>`** in the no-query branch. Its `send` body is `unknown` and always was. Pre-existing. The v1 WebSocket seam is verified at the class level in `test/types/treaty.ts`. Separate fix.
- **Hover text changes** from `{ amount: number; currency: string }` to `Serializable<{ amount: number; currency: string }>`. Same trade the query side already made. Readable, on purpose.
- **Type-check cost**: +0.14s check time across the whole test program with three new test files added. Noise.

Runtime is untouched. It was already honoring `toJSON`. It was only ever the types lying to you.

Now. Anything *actually* wrong, or are we done here?
