### PR TITLE
feat(treaty): type-safe custom error bodies returned from onError handlers (#313)

### DIFF
--- a/src/treaty/types.ts
+++ b/src/treaty/types.ts
@@ -14,17 +14,19 @@ type Replace<RecordType, TargetType, GenericType> = {
 
 type MaybeArray<T> = T | T[]
 
+type SuccessCodes = 200 | 201 | 202 | 203 | 204 | 205 | 206 | 207 | 208 | 226
+
 export namespace EdenTreaty {
     type GetErrorResponse<App extends Elysia<any, any, any, any, any, any, any>> =
         App extends Elysia<any, any, any, infer Metadata, any, infer Ephemeral, infer Volatile>
             ? (Metadata['response'] & Ephemeral['response'] & Volatile['response']) extends infer Res
-                ? Exclude<keyof Res, 200> extends never
-                    ? Res[keyof Res]
+                ? Exclude<keyof Res, SuccessCodes> extends never
+                    ? never
                     : {
-                            [Status in keyof Res]: Res[Status]
-                      }[Exclude<keyof Res, 200>]
-                : unknown
-            : unknown
+                            [Status in keyof Res as Status extends SuccessCodes ? never : Status]: Res[Status]
+                      }
+                : never
+            : never
 
     export type Create<
         App extends Elysia<any, any, any, any, any, any, any>
@@ -36,7 +38,7 @@ export namespace EdenTreaty {
 
     export type Sign<
         Route extends Record<string, any>,
-        ErrorResponse = unknown
+        ErrorResponse = never
     > = {
         [K in keyof Route as K extends `:${string}`
             ? (string & {}) | number | K
@@ -98,10 +100,14 @@ export namespace EdenTreaty {
                                         ? IsNever<Errors> extends true
                                             ? IsNever<ErrorResponse> extends true
                                                 ? EdenFetchError<number, string>
-                                                : EdenFetchError<number, ErrorResponse>
+                                                : ErrorResponse extends Record<number, unknown>
+                                                    ? { [Status in keyof ErrorResponse & number]: EdenFetchError<Status, ErrorResponse[Status]> }[keyof ErrorResponse & number]
+                                                    : EdenFetchError<number, ErrorResponse>
                                             : Errors | (IsNever<ErrorResponse> extends true
                                                 ? never
-                                                : EdenFetchError<number, ErrorResponse>)
+                                                : ErrorResponse extends Record<number, unknown>
+                                                    ? { [Status in keyof ErrorResponse & number]: EdenFetchError<Status, ErrorResponse[Status]> }[keyof ErrorResponse & number]
+                                                    : EdenFetchError<number, ErrorResponse>)
                                         : EdenFetchError<number, string>
                                     : EdenFetchError<number, unknown>
                             }

--- a/src/treaty/types.ts
+++ b/src/treaty/types.ts
@@ -15,15 +15,29 @@ type Replace<RecordType, TargetType, GenericType> = {
 type MaybeArray<T> = T | T[]
 
 export namespace EdenTreaty {
+    type GetErrorResponse<App extends Elysia<any, any, any, any, any, any, any>> =
+        App extends Elysia<any, any, any, infer Metadata, any, infer Ephemeral, infer Volatile>
+            ? (Metadata['response'] & Ephemeral['response'] & Volatile['response']) extends infer Res
+                ? Exclude<keyof Res, 200> extends never
+                    ? Res[keyof Res]
+                    : {
+                            [Status in keyof Res]: Res[Status]
+                      }[Exclude<keyof Res, 200>]
+                : unknown
+            : unknown
+
     export type Create<
         App extends Elysia<any, any, any, any, any, any, any>
     > = App extends {
         '~Routes': infer Schema extends Record<string, unknown>
     }
-        ? Prettify<Sign<Schema>>
+        ? Prettify<Sign<Schema, GetErrorResponse<App>>>
         : 'Please install Elysia before using Eden'
 
-    export type Sign<Route extends Record<string, any>> = {
+    export type Sign<
+        Route extends Record<string, any>,
+        ErrorResponse = unknown
+    > = {
         [K in keyof Route as K extends `:${string}`
             ? (string & {}) | number | K
             : K extends '' | '/'
@@ -82,8 +96,12 @@ export namespace EdenTreaty {
                                 error: Response extends Record<number, unknown>
                                     ? MapError<Response> extends infer Errors
                                         ? IsNever<Errors> extends true
-                                            ? EdenFetchError<number, string>
-                                            : Errors
+                                            ? IsNever<ErrorResponse> extends true
+                                                ? EdenFetchError<number, string>
+                                                : EdenFetchError<number, ErrorResponse>
+                                            : Errors | (IsNever<ErrorResponse> extends true
+                                                ? never
+                                                : EdenFetchError<number, ErrorResponse>)
                                         : EdenFetchError<number, string>
                                     : EdenFetchError<number, unknown>
                             }
@@ -121,7 +139,7 @@ export namespace EdenTreaty {
                           }
                       ) => Response
                 : never
-            : Prettify<Sign<Route[K]>>
+            : Prettify<Sign<Route[K], ErrorResponse>>
     }
 
     type UnwrapPromise<T> = T extends Promise<infer A> ? A : T

--- a/src/treaty2/types.ts
+++ b/src/treaty2/types.ts
@@ -81,6 +81,17 @@ type SerializeQueryParams<T> =
 		: T
 
 export namespace Treaty {
+	type GetErrorResponse<App extends Elysia<any, any, any, any, any, any, any>> =
+		App extends Elysia<any, any, any, infer Metadata, any, infer Ephemeral, infer Volatile>
+			? (Metadata['response'] & Ephemeral['response'] & Volatile['response']) extends infer Res
+				? Exclude<keyof Res, SuccessCodes> extends never
+					? Res[keyof Res]
+					: {
+							[Status in keyof Res]: Res[Status]
+					  }[Exclude<keyof Res, SuccessCodes>]
+				: unknown
+			: unknown
+
 	export interface TreatyParam {
 		fetch?: RequestInit
 		throwHttpError?: ThrowHttpError
@@ -92,7 +103,7 @@ export namespace Treaty {
 	> = App extends {
 		'~Routes': infer Schema extends Record<any, any>
 	}
-		? Prettify<Sign<Schema, Head>> & CreateParams<Schema, Head>
+		? Prettify<Sign<Schema, Head, GetErrorResponse<App>>> & CreateParams<Schema, Head, GetErrorResponse<App>>
 		: 'Please install Elysia before using Eden'
 
 	type ToTreatyParam<Target, Head extends Record<string, unknown>> = Prettify<
@@ -110,7 +121,8 @@ export namespace Treaty {
 
 	export type Sign<
 		in out Route extends Record<any, any>,
-		in out Head extends Record<string, unknown> = {}
+		in out Head extends Record<string, unknown> = {},
+		ErrorResponse = unknown
 	> = {
 		[K in keyof Route as K extends `:${string}`
 			? never
@@ -141,7 +153,8 @@ export namespace Treaty {
 											options?: ToTreatyParam<Param, Head>
 										) => Promise<
 											TreatyResponse<
-												ReplaceGeneratorWithAsyncGenerator<Res>
+												ReplaceGeneratorWithAsyncGenerator<Res>,
+												ErrorResponse
 											>
 										>
 									: (
@@ -149,7 +162,8 @@ export namespace Treaty {
 											options?: ToTreatyParam<Param, Head>
 										) => Promise<
 											TreatyResponse<
-												ReplaceGeneratorWithAsyncGenerator<Res>
+												ReplaceGeneratorWithAsyncGenerator<Res>,
+												ErrorResponse
 											>
 										>
 								: K extends 'get' | 'head'
@@ -157,7 +171,8 @@ export namespace Treaty {
 											options?: ToTreatyParam<Param, Head>
 										) => Promise<
 											TreatyResponse<
-												ReplaceGeneratorWithAsyncGenerator<Res>
+												ReplaceGeneratorWithAsyncGenerator<Res>,
+												ErrorResponse
 											>
 										>
 									: {} extends Body
@@ -169,7 +184,8 @@ export namespace Treaty {
 												>
 											) => Promise<
 												TreatyResponse<
-													ReplaceGeneratorWithAsyncGenerator<Res>
+													ReplaceGeneratorWithAsyncGenerator<Res>,
+													ErrorResponse
 												>
 											>
 										: (
@@ -180,7 +196,8 @@ export namespace Treaty {
 												>
 											) => Promise<
 												TreatyResponse<
-													ReplaceGeneratorWithAsyncGenerator<Res>
+													ReplaceGeneratorWithAsyncGenerator<Res>,
+													ErrorResponse
 												>
 											>
 							: K extends 'get' | 'head'
@@ -188,7 +205,8 @@ export namespace Treaty {
 										options: ToTreatyParam<Param, Head>
 									) => Promise<
 										TreatyResponse<
-											ReplaceGeneratorWithAsyncGenerator<Res>
+											ReplaceGeneratorWithAsyncGenerator<Res>,
+											ErrorResponse
 										>
 									>
 								: (
@@ -196,22 +214,24 @@ export namespace Treaty {
 										options: ToTreatyParam<Param, Head>
 									) => Promise<
 										TreatyResponse<
-											ReplaceGeneratorWithAsyncGenerator<Res>
+											ReplaceGeneratorWithAsyncGenerator<Res>,
+											ErrorResponse
 										>
 									>
 						: never
-					: CreateParams<Route[K], Head>) & {
+					: CreateParams<Route[K], Head, ErrorResponse>) & {
 					'~path': string
 				}
 	}
 
 	type CreateParams<
 		Route extends Record<string, any>,
-		Head extends Record<string, unknown> = {}
+		Head extends Record<string, unknown> = {},
+		ErrorResponse = unknown
 	> =
 		Extract<keyof Route, `:${string}`> extends infer Path extends string
 			? IsNever<Path> extends true
-				? Prettify<Sign<Route, Head>>
+				? Prettify<Sign<Route, Head, ErrorResponse>>
 				: // ! DO NOT USE PRETTIFY ON THIS LINE, OTHERWISE FUNCTION CALLING WILL BE OMITTED
 					(((params: {
 						[param in Path extends `:${infer Param}`
@@ -220,14 +240,14 @@ export namespace Treaty {
 								: Param
 							: never]: string | number
 					}) => Prettify<
-						Sign<Route[Path], Head> & {
+						Sign<Route[Path], Head, ErrorResponse> & {
 							'~path': string
 						}
 					> &
-						CreateParams<Route[Path], Head>) &
-						Prettify<Sign<Route, Head>>) &
+						CreateParams<Route[Path], Head, ErrorResponse>) &
+						Prettify<Sign<Route, Head, ErrorResponse>>) &
 						(Path extends `:${string}?`
-							? CreateParams<Route[Path], Head>
+							? CreateParams<Route[Path], Head, ErrorResponse>
 							: {})
 			: never
 
@@ -266,7 +286,10 @@ export namespace Treaty {
 	//     [K in keyof T]: Awaited<T[K]>
 	// }
 
-	export type TreatyResponse<Res extends Record<number, unknown>> =
+	export type TreatyResponse<
+		Res extends Record<number, unknown>,
+		ErrorResponse = unknown
+	> =
 		| {
 				data: Res[Extract<keyof Res, SuccessCodes>] extends {
 					[ELYSIA_FORM_DATA]: infer Data
@@ -281,11 +304,17 @@ export namespace Treaty {
 		| {
 				data: null
 				error: Exclude<keyof Res, SuccessCodes> extends never
-					? {
-							status: unknown
-							value: unknown
-						}
-					: {
+					? IsNever<ErrorResponse> extends true
+						? {
+								status: unknown
+								value: unknown
+						  }
+						: {
+								status: unknown
+								value: ErrorResponse
+						  }
+					: (
+						{
 							[Status in keyof Res]: {
 								status: Status
 								value: Res[Status] extends {
@@ -295,6 +324,12 @@ export namespace Treaty {
 									: Res[Status]
 							}
 						}[Exclude<keyof Res, SuccessCodes>]
+					) | (IsNever<ErrorResponse> extends true
+						? never
+						: {
+								status: unknown
+								value: ErrorResponse
+						  })
 				response: Response
 				status: number
 				headers: ResponseInit['headers']

--- a/src/treaty2/types.ts
+++ b/src/treaty2/types.ts
@@ -85,12 +85,12 @@ export namespace Treaty {
 		App extends Elysia<any, any, any, infer Metadata, any, infer Ephemeral, infer Volatile>
 			? (Metadata['response'] & Ephemeral['response'] & Volatile['response']) extends infer Res
 				? Exclude<keyof Res, SuccessCodes> extends never
-					? Res[keyof Res]
+					? never
 					: {
-							[Status in keyof Res]: Res[Status]
-					  }[Exclude<keyof Res, SuccessCodes>]
-				: unknown
-			: unknown
+							[Status in keyof Res as Status extends SuccessCodes ? never : Status]: Res[Status]
+					  }
+				: never
+			: never
 
 	export interface TreatyParam {
 		fetch?: RequestInit
@@ -122,7 +122,7 @@ export namespace Treaty {
 	export type Sign<
 		in out Route extends Record<any, any>,
 		in out Head extends Record<string, unknown> = {},
-		ErrorResponse = unknown
+		ErrorResponse = never
 	> = {
 		[K in keyof Route as K extends `:${string}`
 			? never
@@ -227,7 +227,7 @@ export namespace Treaty {
 	type CreateParams<
 		Route extends Record<string, any>,
 		Head extends Record<string, unknown> = {},
-		ErrorResponse = unknown
+		ErrorResponse = never
 	> =
 		Extract<keyof Route, `:${string}`> extends infer Path extends string
 			? IsNever<Path> extends true
@@ -288,7 +288,7 @@ export namespace Treaty {
 
 	export type TreatyResponse<
 		Res extends Record<number, unknown>,
-		ErrorResponse = unknown
+		ErrorResponse = never
 	> =
 		| {
 				data: Res[Extract<keyof Res, SuccessCodes>] extends {
@@ -309,10 +309,17 @@ export namespace Treaty {
 								status: unknown
 								value: unknown
 						  }
-						: {
-								status: unknown
-								value: ErrorResponse
-						  }
+						: ErrorResponse extends Record<number, unknown>
+							? {
+									[K in keyof ErrorResponse & number]: {
+										status: K
+										value: ErrorResponse[K]
+									}
+							  }[keyof ErrorResponse & number]
+							: {
+									status: unknown
+									value: ErrorResponse
+							  }
 					: (
 						{
 							[Status in keyof Res]: {
@@ -326,10 +333,17 @@ export namespace Treaty {
 						}[Exclude<keyof Res, SuccessCodes>]
 					) | (IsNever<ErrorResponse> extends true
 						? never
-						: {
-								status: unknown
-								value: ErrorResponse
-						  })
+						: ErrorResponse extends Record<number, unknown>
+							? {
+									[K in keyof ErrorResponse & number]: {
+										status: K
+										value: ErrorResponse[K]
+									}
+							  }[keyof ErrorResponse & number]
+							: {
+									status: unknown
+									value: ErrorResponse
+							  })
 				response: Response
 				status: number
 				headers: ResponseInit['headers']

--- a/test/treaty2.test.ts
+++ b/test/treaty2.test.ts
@@ -1448,7 +1448,32 @@ describe('Treaty2 - parseDate configuration', () => {
 	it('should NOT parse date in text response when parseDate is false', async () => {
 		const client = treaty(dateApp, { parseDate: false })
 		const { data } = await client['text-date'].get()
-
 		expect(data).toBe('2024-01-15T10:30:00.000Z')
+	})
+})
+
+describe('Treaty2 - custom error from onError', () => {
+	it('should return type-safe custom error bodies from onError handler', async () => {
+		const app = new Elysia()
+			.onError(({ code, error, set }) => {
+				set.status = 500
+				return {
+					customError: error.message,
+					code
+				}
+			})
+			.get('/', () => {
+				throw new Error('Something went wrong!')
+			})
+
+		const client = treaty(app)
+		const { data, error } = await client.get()
+
+		expect(data).toBeNull()
+		expect(error?.status).toBe(500)
+		expect(error?.value).toEqual({
+			customError: 'Something went wrong!',
+			code: 'UNKNOWN'
+		})
 	})
 })

--- a/test/types/treaty2.ts
+++ b/test/types/treaty2.ts
@@ -1,5 +1,5 @@
 import { Elysia, file, form, status, t } from 'elysia'
-import { treaty } from '../../src'
+import { treaty, edenTreaty } from '../../src'
 import { expectTypeOf } from 'expect-type'
 import type { ThrowHttpError } from '../../src/types'
 
@@ -1415,4 +1415,30 @@ type ValidationError = {
 
 	expectTypeOf(api.id({ id: 1 })['~path']).toEqualTypeOf<string>()
 	expectTypeOf(api.nested.q['~path']).toEqualTypeOf<string>()
+}
+
+// ? Custom error from onError hook type inference
+{
+	const app = new Elysia()
+		.onError(({ code, error }) => {
+			return {
+				customError: error instanceof Error ? error.message : 'no message',
+				code
+			}
+		})
+		.get('/', () => 'hello')
+
+	const client2 = treaty(app)
+	type Err2 = NonNullable<Result<typeof client2.get>['error']>
+	expectTypeOf<Err2['value']>().toEqualTypeOf<{
+		customError: string
+		code: number | "INTERNAL_SERVER_ERROR" | "NOT_FOUND" | "PARSE" | "INVALID_COOKIE_SIGNATURE" | "INVALID_FILE_TYPE" | "VALIDATION" | "UNKNOWN"
+	}>()
+
+	const client1 = edenTreaty<typeof app>('http://localhost')
+	type Err1 = NonNullable<Result<typeof client1.get>['error']>
+	expectTypeOf<Err1['value']>().toEqualTypeOf<{
+		customError: string
+		code: number | "INTERNAL_SERVER_ERROR" | "NOT_FOUND" | "PARSE" | "INVALID_COOKIE_SIGNATURE" | "INVALID_FILE_TYPE" | "VALIDATION" | "UNKNOWN"
+	}>()
 }


### PR DESCRIPTION
Fixes #313.

### Summary
Enhances Eden Treaty type definitions to infer and preserve custom JSON error bodies and status codes returned from `onError` handlers, allowing type-safe error inspection on Eden client calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Custom error responses from server error handlers are now exposed through the client with accurate status codes and response data.
  - Improved type inference distinguishes successful responses from error responses across Treaty clients and route methods.
  - Error response details are now associated with their specific status codes for more predictable client handling.

- **Tests**
  - Added coverage for custom error response handling and type inference in both Treaty client variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->